### PR TITLE
Add an optional delay in ask()

### DIFF
--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -636,16 +636,19 @@ class Instrument(_BaseInstrument):
         except ValueError as e:
             raise errors.InvalidBinaryFormat(e.args)
 
-    def ask(self, message):
+    def ask(self, message, delay=0):
         """A combination of write(message) and read()
 
         :param message: the message to send.
         :type message: str
+        :[param delay]: the delay between write and read.
+        :[type delay]: int
         :returns: the answer from the device.
         :rtype: str
         """
 
         self.write(message)
+        time.sleep(delay)
         return self.read()
 
     def ask_for_values(self, message, format=None):


### PR DESCRIPTION
Hi hgrecco, ask() could be more useful if there's an optional delay between write() and read(), since for different SCPI commands, it takes different time for instruments to finish, and if one tries to read before the command has been executed, a timeout exception could be easily thrown.

so I recommend to add an optional delay in ask(), otherwise in many cases this method is not practical.
