### PR TITLE
fix(highlevel): added resource_name to parse_resource_extended

### DIFF
--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -1035,7 +1035,8 @@ class VisaLibraryBase(object):
 
             return (ResourceInfo(parsed.interface_type_const,
                                  parsed.board,
-                                 parsed.resource_class, None, None),
+                                 parsed.resource_class,
+                                 str(parsed), None),
                     constants.StatusCode.success)
         except ValueError:
             return 0, constants.StatusCode.error_invalid_resource_name


### PR DESCRIPTION
Using ResourceManager.resource_info returned inconsistent results
between the NI-VISA backend vs other backends which didn't extend
visalib.parse_resource_extended (e.g. PyVISA-sim) and code relying
on the "normalization" behavior of resource_info.resource_name
would not work.
