### PR TITLE
Enable Exceptions to be pickled/unpickled

### DIFF
--- a/pyvisa/errors.py
+++ b/pyvisa/errors.py
@@ -368,6 +368,9 @@ class VisaIOError(Error):
         self.error_code = error_code
         self.abbreviation = abbreviation
         self.description = description
+        
+    def __reduce__(self):
+        return (VisaIOError, (self.error_code,))
 
 
 class VisaIOWarning(Warning):
@@ -384,6 +387,9 @@ class VisaIOWarning(Warning):
         self.error_code = error_code
         self.abbreviation = abbreviation
         self.description = description
+        
+    def __reduce__(self):
+        return (VisaIOWarning, (self.error_code,))
 
 
 class VisaTypeError(Error):
@@ -410,12 +416,22 @@ class UnknownHandler(Error):
 
     def __init__(self, event_type, handler, user_handle):
         super(UnknownHandler, self).__init__('%s, %s, %s' % (event_type, handler, user_handle))
+        self.event_type = event_type
+        self.handler = handler
+        self.user_handle = user_handle
+        
+    def __reduce__(self):
+        return (UnknownHandler, (self.event_type, self.handler, self.user_handle))
 
 
 class OSNotSupported(Error):
 
     def __init__(self, os):
         super(OSNotSupported, self).__init__(os + " is not yet supported by PyVISA")
+        self.os = os
+        
+    def __reduce__(self):
+        return (OSNotSupported, (self.os,))
 
 
 class InvalidBinaryFormat(Error):
@@ -424,6 +440,10 @@ class InvalidBinaryFormat(Error):
         if description:
             description = ": " + description
         super(InvalidBinaryFormat, self).__init__("Unrecognized binary data format" + description)
+        self.description = description
+
+    def __reduce__(self):
+        return (InvalidBinaryFormat, (self.description,))        
 
 
 class InvalidSession(Error):
@@ -432,6 +452,9 @@ class InvalidSession(Error):
 
     def __init__(self):
         super(InvalidSession, self).__init__('Invalid session handle. The resource might be closed.')
+
+    def __reduce__(self):
+        return (InvalidSession, ())
 
 
 class LibraryError(OSError, Error):

--- a/pyvisa/errors.py
+++ b/pyvisa/errors.py
@@ -351,6 +351,9 @@ class Error(Exception):
 
     def __init__(self, description):
         super(Error, self).__init__(description)
+        
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
 
 
 class VisaIOError(Error):
@@ -390,6 +393,9 @@ class VisaIOWarning(Warning):
         
     def __reduce__(self):
         return (VisaIOWarning, (self.error_code,))
+        
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
 
 
 class VisaTypeError(Error):

--- a/pyvisa/testsuite/test_errors.py
+++ b/pyvisa/testsuite/test_errors.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, unicode_literals, print_function, absolute_import
+
+import pickle
+
+from pyvisa.testsuite import BaseTestCase
+
+from pyvisa import errors
+
+
+class TestPicleUnpickle(BaseTestCase):
+    def _test_pickle_unpickle(self, instance):
+        pickled = pickle.dumps(instance)
+        unpickled = pickle.loads(pickled)
+        self.assertIsInstance(unpickled, type(instance))
+        self.assertEqual(instance, unpickled)
+
+    def test_VisaIOError(self):
+        self._test_pickle_unpickle(errors.VisaIOError(0))
+        
+    def test_VisaIOWarning(self):
+        self._test_pickle_unpickle(errors.VisaIOWarning(0))
+        
+    def test_UnknownHandler(self):
+        self._test_pickle_unpickle(errors.UnknownHandler(0,0,0))
+        
+    def test_OSNotSupported(self):
+        self._test_pickle_unpickle(errors.OSNotSupported(""))
+        
+    def test_InvalidBinaryFormat(self):
+        self._test_pickle_unpickle(errors.InvalidBinaryFormat())
+        
+    def InvalidSession(self):
+        self._test_pickle_unpickle(errors.InvalidSession())


### PR DESCRIPTION
Fixes a bug when trying to pickle/unpickle pyvisa exceptions. For example, previously it was not possible to send an exception instance from one process to another through a pipe.