### PR TITLE
visa command line can use non-default backend

### DIFF
--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -105,6 +105,56 @@ Finally, you can close the device::
     (open) close
 
 
+PyVisa Shell Backends
+=====================
+
+Based on available backend (see bellow for ``info`` command), it is possible to switch shell to use non-default backend via
+``-b BACKEND`` or ``--backend BACKEND``.
+
+You can invoke::
+
+    python -m visa -b sim shell
+
+to use python-sim as backend instead of ni backend. 
+This can be used for example for testing of python-sim configuration.
+
+You can invoke::
+
+    python -m visa -b py shell
+
+uses python-py as backend instead of ni backend, for situation when ni not installed.
+
+
+PyVisa Info
+===========
+
+You can invoke it from the command-line::
+
+    python -m visa info
+
+that will  print information to diagnose PyVISA, info about Machine, Python, backends, etc ::
+
+    Machine Details:
+       Platform ID:    Windows
+       Processor:      Intel64 Family 6
+       ...
+    PyVISA Version: ...
+
+    Backends:
+       ni:
+          Version: 1.8 (bundled with PyVISA)
+          ...
+       py:
+          Version: 0.2
+          ...
+      sim:
+         Version: 0.3
+         Spec version: 1.1
+
+
+Summary
+=======
+
 Cool, right? It will be great to have a GUI similar to NI-MAX, but we leave that to be developed outside PyVISA.
 Want to help? Let us know!
 

--- a/visa.py
+++ b/visa.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='PyVISA command-line utilities')
 
     parser.add_argument('--backend', '-b', dest='backend', action='store', default=None,
-                    help='backend to be used (default: ni)')
+                        help='backend to be used (default: ni)')
 
     subparsers = parser.add_subparsers(title='command', dest='command')
 

--- a/visa.py
+++ b/visa.py
@@ -24,6 +24,10 @@ from pyvisa.resources import Resource
 if __name__ == '__main__':
     import argparse
     parser = argparse.ArgumentParser(description='PyVISA command-line utilities')
+
+    parser.add_argument('--backend', '-b', dest='backend', action='store', default=None,
+                    help='backend to be used (default: ni)')
+
     subparsers = parser.add_subparsers(title='command', dest='command')
 
     info_parser = subparsers.add_parser('info', help='print information to diagnose PyVISA')
@@ -36,4 +40,4 @@ if __name__ == '__main__':
         util.get_debug_info()
     elif args.command == 'shell':
         from pyvisa import shell
-        shell.main()
+        shell.main('@' + args.backend if args.backend else '')


### PR DESCRIPTION
in `visa` command line tool it was not possible to setup backend, ni-visa  is used as default.

New option is supported (short and long form):
```
-b BACKEND
--backend BACKEND
```

Examples

`python -m visa shell` runs as currently supported functionality
`python -m visa -b pyshell` runs with `python-py` backend, useful when ni-visa not installed
`python -m visa -b sim shell` runs with `python-sim` backend, useful for resting pyvisa simulator configuration

(related to #195)

