### PR TITLE
shell: support for 'termchar' command

### DIFF
--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -112,7 +112,9 @@ We can also get a list of all visa attributes::
 
 
 To simplify handling of VI_ATTR_TERMCHAR and VI_ATTR_TERMCHAR_EN, command 'termchar' can be used.
-To setup termchat to '\r' (CR or ascii code 10)::
+It also sets write termination character.
+
+To setup termchar to '\r' (CR or ascii code 10)::
 
     (open) termchar CR
     Done
@@ -120,7 +122,7 @@ To setup termchat to '\r' (CR or ascii code 10)::
 To read what termchar is defined::
 
     (open) termchar
-    Termchar: CR
+    Termchar read: CR write: CR
 
 Supported termchar values are: CR ('\r'), LF ('\n'), CRLF ('\r\n') , NUL ('\0'), None. None is used to disable termchar.
 

--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -122,7 +122,7 @@ To read what termchar is defined::
     (open) termchar
     Termchar: CR
 
-Supported termchar values are: CR, LF, CRLF, None. None is used to disable termchar.
+Supported termchar values are: CR ('\r'), LF ('\n'), CRLF ('\r\n') , NUL ('\0'), None. None is used to disable termchar.
 
 
 Finally, you can close the device::

--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -111,9 +111,9 @@ We can also get a list of all visa attributes::
     +-----------------------------+------------+----------------------------+-------------------------------------+
 
 
-To simplify handling of VI_ATTR_TERMCHAR and VI_ATTR_TERMCHAR_EN, command 'termchar' can be used.
-It also sets same write termination character, if only one character provided.
-If two characters provided, it sets read and write termination character independently.
+To simplify the handling of VI_ATTR_TERMCHAR and VI_ATTR_TERMCHAR_EN, the command 'termchar' can be used.
+If only one character provided, it sets both read and write termination character to the same character.
+If two characters are provided, it sets read and write termination characters independently.
 
 To setup termchar to '\r' (CR or ascii code 10)::
 

--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -112,7 +112,8 @@ We can also get a list of all visa attributes::
 
 
 To simplify handling of VI_ATTR_TERMCHAR and VI_ATTR_TERMCHAR_EN, command 'termchar' can be used.
-It also sets write termination character.
+It also sets same write termination character, if only one character provided.
+If two characters provided, it sets read and write termination character independently.
 
 To setup termchar to '\r' (CR or ascii code 10)::
 
@@ -124,7 +125,13 @@ To read what termchar is defined::
     (open) termchar
     Termchar read: CR write: CR
 
-Supported termchar values are: CR ('\r'), LF ('\n'), CRLF ('\r\n') , NUL ('\0'), None. None is used to disable termchar.
+To setup read termchar to '\n' and write termchar to '\r\n\'::
+
+    (open) termchar LF CRLF
+    Done
+
+Supported termchar values are: CR ('\r'), LF ('\n'), CRLF ('\r\n') , NUL ('\0'), None.
+None is used to disable termchar.
 
 
 Finally, you can close the device::

--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -100,6 +100,21 @@ We can also get a list of all visa attributes::
     |     VI_ATTR_WR_BUF_SIZE     | 1073676334 |                            |                 4096                |
     +-----------------------------+------------+----------------------------+-------------------------------------+
 
+
+To simplify handling of VI_ATTR_TERMCHAR and VI_ATTR_TERMCHAR_EN, command 'termchar' can be used.
+To setup termchat to '\r' (CR or ascii code 10)::
+
+    (open) termchar CR
+    Done
+
+To read what termchar is defined::
+
+    (open) termchar
+    Termchar: CR
+
+Supported termchar values are: CR, LF, CRLF, None. None is used to disable termchar.
+
+
 Finally, you can close the device::
 
     (open) close

--- a/pyvisa/shell.py
+++ b/pyvisa/shell.py
@@ -362,11 +362,14 @@ class VisaShell(Cmd):
 
         if not args:
             try:
-                ch = self.current.read_termination
                 charmap = { u'\r': 'CR', u'\n': 'LF', u'\r\n': 'CRLF', u'\0': 'NUL' }
-                if(charmap.has_key(ch)):
-                    ch = charmap[ch]
-                print('Termchar: {0}'.format(ch))
+                chr = self.current.read_termination
+                if(charmap.has_key(chr)):
+                    chr = charmap[chr]
+                chw = self.current.write_termination
+                if(charmap.has_key(chw)):
+                    chw = charmap[chw]
+                print('Termchar read: {0} write: {1}'.format(chr, chw))
             except Exception as e:
                 print(e)
         else:        
@@ -375,6 +378,7 @@ class VisaShell(Cmd):
             if charmap.has_key(args[0]):
                 try:
                     self.current.read_termination = charmap[args[0]]
+                    self.current.write_termination = charmap[args[0]]
                     print('Done')
                 except Exception as e:
                     print(e)

--- a/pyvisa/shell.py
+++ b/pyvisa/shell.py
@@ -307,6 +307,49 @@ class VisaShell(Cmd):
         return [item for item in self.py_attr if item.startswith(text)] + \
                [item for item in self.vi_attr if item.startswith(text)]
 
+    def do_termchar(self, args):
+        """Get or set termination character for resource in use.
+        <termchar> can be one of: CR, LF, CRLF or None.
+        None is used to disable termination character
+        
+        Get termination character:
+
+            termchar
+
+        Set termination character:
+
+            termchar <termchar>
+
+        """
+
+        if not self.current:
+            print('There are no resources in use. Use the command "open".')
+            return
+
+        args = args.strip()
+
+        if not args:
+            try:
+                ch = self.current.read_termination
+                charmap = { u'\r': 'CR', u'\n':'LF', u'\r\n':'CRLF' }
+                if(charmap.has_key(ch)):
+                    ch = charmap[ch]
+                print('Termchar: {0}'.format(ch))
+            except Exception as e:
+                print(e)
+        else:        
+            args = args.split(' ')
+            charmap = { 'CR': u'\r', 'LF': u'\n', 'CRLF': u'\r\n', 'None': None }
+            if charmap.has_key(args[0]):
+                try:
+                    self.current.read_termination = charmap[args[0]]
+                    print('Done')
+                except Exception as e:
+                    print(e)
+            else:
+                print('use CR, LF or CRLF to set termchar')
+                return
+
     def do_exit(self, arg):
         """Exit the shell session."""
 

--- a/pyvisa/shell.py
+++ b/pyvisa/shell.py
@@ -348,9 +348,9 @@ class VisaShell(Cmd):
 
             termchar
 
-        Set termination character:
+        Set termination character read or read+write:
 
-            termchar <termchar>
+            termchar <termchar> [<termchar>]
 
         """
 
@@ -378,7 +378,7 @@ class VisaShell(Cmd):
             if charmap.has_key(args[0]):
                 try:
                     self.current.read_termination = charmap[args[0]]
-                    self.current.write_termination = charmap[args[0]]
+                    self.current.write_termination = charmap[args[0 if len(args) == 1 else 1]]
                     print('Done')
                 except Exception as e:
                     print(e)

--- a/pyvisa/shell.py
+++ b/pyvisa/shell.py
@@ -341,7 +341,7 @@ class VisaShell(Cmd):
 
     def do_termchar(self, args):
         """Get or set termination character for resource in use.
-        <termchar> can be one of: CR, LF, CRLF or None.
+        <termchar> can be one of: CR, LF, CRLF, NUL or None.
         None is used to disable termination character
         
         Get termination character:
@@ -363,7 +363,7 @@ class VisaShell(Cmd):
         if not args:
             try:
                 ch = self.current.read_termination
-                charmap = { u'\r': 'CR', u'\n':'LF', u'\r\n':'CRLF' }
+                charmap = { u'\r': 'CR', u'\n': 'LF', u'\r\n': 'CRLF', u'\0': 'NUL' }
                 if(charmap.has_key(ch)):
                     ch = charmap[ch]
                 print('Termchar: {0}'.format(ch))
@@ -371,7 +371,7 @@ class VisaShell(Cmd):
                 print(e)
         else:        
             args = args.split(' ')
-            charmap = { 'CR': u'\r', 'LF': u'\n', 'CRLF': u'\r\n', 'None': None }
+            charmap = { 'CR': u'\r', 'LF': u'\n', 'CRLF': u'\r\n', 'NUL': u'\0', 'None': None }
             if charmap.has_key(args[0]):
                 try:
                     self.current.read_termination = charmap[args[0]]
@@ -379,7 +379,7 @@ class VisaShell(Cmd):
                 except Exception as e:
                     print(e)
             else:
-                print('use CR, LF or CRLF to set termchar')
+                print('use CR, LF, CRLF, NUL or None to set termchar')
                 return
 
     def do_exit(self, arg):


### PR DESCRIPTION
Added support for termination character (read_termination) setup / read into shell (visa command line tool).

To display termination character
```
(open) termchar
```
To set termination character (read and write)
```
(open) termchar <termchar> [<termchar>]
```
`<termchar>` is one of `CR`, `LF`, `CRLF`, `NUL`.
To disable termination character, `None` shall be used
If two termchars are provided, first is read termination character and second is write termination character