### PR TITLE
Message based improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ python:
   - "3.6"
 
 install:
-  - pip install coverage
-  - pip install coveralls
+  - if [ $TRAVIS_PYTHON_VERSION == '2.7' ] || [ $TRAVIS_PYTHON_VERSION == '3.6' ]; then pip install numpy; fi
+  - pip install coverage coveralls
 
 script:
   - coverage run -p --source=pyvisa --omit="*test*","*compat*" setup.py test

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,10 +44,10 @@ master_doc = 'index'
 # General information about the project.
 project = 'PyVISA'
 author = 'PyVISA Authors'
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-
 version = pkg_resources.get_distribution(project).version
 release = version
 this_year = datetime.date.today().year

--- a/docs/rvalues.rst
+++ b/docs/rvalues.rst
@@ -78,7 +78,7 @@ If you have doubles `d` in big endian the call will be::
 You can also specify the output container type, just as it was shown before.
 
 By default, PyVISA will assume that the data block is formatted according to
-the IEEE convention. If you instrument use HP data block you can pass
+the IEEE convention. If your instrument uses HP data block you can pass
 ``header_fmt='hp'`` to ``read_binary_values``. If your instrument does not use
 any header for the data simply ``header_fmt='empty'``.
 

--- a/docs/rvalues.rst
+++ b/docs/rvalues.rst
@@ -77,6 +77,11 @@ If you have doubles `d` in big endian the call will be::
 
 You can also specify the output container type, just as it was shown before.
 
+By default, PyVISA will assume that the data block is formatted according to
+the IEEE convention. If you instrument use HP data block you can pass
+``header_fmt='hp'`` to ``read_binary_values``. If your instrument does not use
+any header for the data simply ``header_fmt='empty'``.
+
 
 Writing ASCII values
 --------------------
@@ -178,4 +183,12 @@ In those cases, you need to get the data::
 
 and then you need to implement the logic to parse it.
 
+Alternatively if the `read_raw` call fails you can try to read just a few bytes
+using::
 
+        >>> inst.write('CURV?')
+        >>> data = inst.read_bytes(1)
+
+If this call fails it may mean that your instrument did not answer, either
+because it needs more time or because your first instruction was not
+understood.

--- a/pyvisa/compat/__init__.py
+++ b/pyvisa/compat/__init__.py
@@ -13,8 +13,6 @@ from __future__ import (division, unicode_literals, print_function,
                         absolute_import)
 
 import sys
-import unittest
-from subprocess import check_output
 
 
 PYTHON3 = sys.version >= '3'
@@ -46,6 +44,7 @@ else:
 
     # The 2 following function implementation extracted from the python-future
     # project
+    import collections
 
     def int_to_bytes(integer, length, byteorder='big', signed=False):
         """

--- a/pyvisa/compat/__init__.py
+++ b/pyvisa/compat/__init__.py
@@ -31,6 +31,8 @@ if PYTHON3:
     input = input
 
     int_to_bytes = int.to_bytes
+    int_from_bytes = int.from_bytes
+
 else:
     string_types = basestring
 

--- a/pyvisa/compat/__init__.py
+++ b/pyvisa/compat/__init__.py
@@ -46,7 +46,7 @@ else:
     # project
     import collections
 
-    def int_to_bytes(integer, length, byteorder='big', signed=False):
+    def int_to_bytes(integer, length, byteorder, signed=False):
         """
         Return an array of bytes representing an integer.
         The integer is represented using length bytes.  An OverflowError is

--- a/pyvisa/compat/__init__.py
+++ b/pyvisa/compat/__init__.py
@@ -14,7 +14,6 @@ from __future__ import (division, unicode_literals, print_function,
 
 import sys
 import unittest
-
 from subprocess import check_output
 
 
@@ -123,17 +122,6 @@ else:
         if signed and (b[0] & 0x80):
             num = num - (2 ** (len(b)*8))
         return num
-
-if sys.version_info < (2, 7):
-    try:
-        # noinspection PyPackageRequirements
-        import unittest2 as unittest
-    except ImportError:
-        raise Exception("Testing PyVISA in Python 2.6 requires package 'unittest2'")
-
-    import struct
-else:
-    import unittest
 
 try:
     from collections import OrderedDict

--- a/pyvisa/compat/struct.py
+++ b/pyvisa/compat/struct.py
@@ -9,7 +9,8 @@
     :license: PSF License
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import sys
 import struct

--- a/pyvisa/constants.py
+++ b/pyvisa/constants.py
@@ -688,7 +688,7 @@ class InterfaceType(enum.IntEnum):
 
 class AddressState(enum.IntEnum):
 
-    unaddressed =VI_GPIB_UNADDRESSED
+    unaddressed = VI_GPIB_UNADDRESSED
     talker = VI_GPIB_TALKER
     listenr = VI_GPIB_LISTENER
 

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -435,6 +435,9 @@ class MessageBasedResource(Resource):
                                                              is_big_endian)
             expected_length = offset + data_length
 
+        if self._read_termination is not None:
+            expected_length += len(self._read_termination)
+
         while len(block) < expected_length:
             block.extend(self._read_raw())
 

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -254,7 +254,7 @@ class MessageBasedResource(Resource):
 
         block = util.to_ascii_block(values, converter, separator)
 
-        message = message.encode(enco) + block
+        message = message.encode(enco) + block.encode(enco)
 
         if term:
             message += term.encode(enco)

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -11,7 +11,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import contextlib
 import time
@@ -47,7 +48,8 @@ class ValuesFormat(object):
         self.container = container
         self.is_binary = False
 
-    def use_binary(self, datatype, is_big_endian, container=list, header_fmt='ieee'):
+    def use_binary(self, datatype, is_big_endian, container=list,
+                   header_fmt='ieee'):
         self.datatype = datatype
         self.is_big_endian = is_big_endian
         self.container = container
@@ -57,18 +59,20 @@ class ValuesFormat(object):
 
 class ControlRenMixin(object):
     """Common controlt_ren method of some messaged based resources.
+
     """
     # It should work for GPIB, USB and some TCPIP
-    # For TCPIP I found some (all?) NI's VISA library do not handle control_ren, but
-    # it works for Agilent's VISA library (at least some of them)
+    # For TCPIP I found some (all?) NI's VISA library do not handle
+    # control_ren, but it works for Agilent's VISA library (at least some of
+    # them)
     def control_ren(self, mode):
-        """Controls the state of the GPIB Remote Enable (REN) interface line, and optionally the remote/local
-        state of the device.
+        """Controls the state of the GPIB Remote Enable (REN) interface line,
+        and optionally the remote/local state of the device.
 
         Corresponds to viGpibControlREN function of the VISA library.
 
-        :param mode: Specifies the state of the REN line and optionally the device remote/local state.
-                     (Constants.GPIB_REN*)
+        :param mode: Specifies the state of the REN line and optionally the
+                     device remote/local state. (Constants.GPIB_REN*)
         :return: return value of the library call.
         :rtype: VISAStatus
         """
@@ -95,17 +99,21 @@ class MessageBasedResource(Resource):
         self._values_format = ValuesFormat()
         super(MessageBasedResource, self).__init__(*args, **kwargs)
 
-    # This is done for backwards compatibility but will be removed in 1.7
+    # This is done for backwards compatibility but will be removed in 1.10
     @property
     def values_format(self):
+        warnings.warn('values_format is deprecated and will be removed in '
+                      '1.10', DeprecationWarning)
         return self._values_format
 
     @values_format.setter
     def values_format(self, fmt):
+        warnings.warn('values_format is deprecated and will be removed in '
+                      '1.10', DeprecationWarning)
         self._values_format.is_binary = not (fmt & 0x01 == 0)
-        if fmt & 0x03 == 1: #single
+        if fmt & 0x03 == 1:  # single
             self._values_format.datatype = 'f'
-        elif fmt & 0x03 == 3: #double:
+        elif fmt & 0x03 == 3:  # double:
             self._values_format.datatype = 'd'
         else:
             raise ValueError("unknown data values fmt requested")
@@ -118,10 +126,14 @@ class MessageBasedResource(Resource):
     def ask_delay(self):
         """An alias for query_delay kept for backwards compatibility.
         """
+        warnings.warn('ask_delay is deprecated and will be removed in '
+                      '1.10, use query_delay instead', DeprecationWarning)
         return self.query_delay
 
     @ask_delay.setter
     def ask_delay(self, value):
+        warnings.warn('ask_delay is deprecated and will be removed in '
+                      '1.10, use query_delay instead', DeprecationWarning)
         self.query_delay = value
 
     @property
@@ -132,7 +144,8 @@ class MessageBasedResource(Resource):
 
     @encoding.setter
     def encoding(self, encoding):
-        _ = 'test encoding'.encode(encoding).decode(encoding)
+        # Test that the encoding specified makes sense.
+        'test encoding'.encode(encoding).decode(encoding)
         self._encoding = encoding
 
     @property
@@ -145,22 +158,25 @@ class MessageBasedResource(Resource):
     def read_termination(self, value):
 
         if value:
-            # termination character, the rest is just used for verification after
-            # each read operation.
+            # termination character, the rest is just used for verification
+            # after each read operation.
             last_char = value[-1:]
-            # Consequently, it's illogical to have the real termination character
-            # twice in the sequence (otherwise reading would stop prematurely).
+            # Consequently, it's illogical to have the real termination
+            # character twice in the sequence (otherwise reading would stop
+            # prematurely).
 
             if last_char in value[:-1]:
                 raise ValueError("ambiguous ending in termination characters")
 
             self.set_visa_attribute(constants.VI_ATTR_TERMCHAR, ord(last_char))
-            self.set_visa_attribute(constants.VI_ATTR_TERMCHAR_EN, constants.VI_TRUE)
+            self.set_visa_attribute(constants.VI_ATTR_TERMCHAR_EN,
+                                    constants.VI_TRUE)
         else:
-            # The termchar is also used in VI_ATTR_ASRL_END_IN (for serial termination)
-            # so return it to its default.
+            # The termchar is also used in VI_ATTR_ASRL_END_IN (for serial
+            # termination) so return it to its default.
             self.set_visa_attribute(constants.VI_ATTR_TERMCHAR, ord(self.LF))
-            self.set_visa_attribute(constants.VI_ATTR_TERMCHAR_EN, constants.VI_FALSE)
+            self.set_visa_attribute(constants.VI_ATTR_TERMCHAR_EN,
+                                    constants.VI_FALSE)
 
         self._read_termination = value
 
@@ -208,8 +224,10 @@ class MessageBasedResource(Resource):
 
         return count
 
-    def write_ascii_values(self, message, values, converter='f', separator=',', termination=None, encoding=None):
-        """Write a string message to the device followed by values in ascii format.
+    def write_ascii_values(self, message, values, converter='f', separator=',',
+                           termination=None, encoding=None):
+        """Write a string message to the device followed by values in ascii
+        format.
 
         The write_termination is always appended to it.
 
@@ -220,8 +238,8 @@ class MessageBasedResource(Resource):
                           String formatting codes are also accepted.
                           Defaults to str.
         :type converter: callable | str
-        :param separator: a callable that split the str into individual elements.
-                          If a str is given, data.split(separator) is used.
+        :param separator: a callable that join the values in a single str.
+                          If a str is given, separator.join(values) is used.
         :type: separator: (collections.Iterable[T]) -> str | str
         :return: number of bytes written.
         :rtype: int
@@ -245,15 +263,19 @@ class MessageBasedResource(Resource):
 
         return count
 
-    def write_binary_values(self, message, values, datatype='f', is_big_endian=False, termination=None, encoding=None):
-        """Write a string message to the device followed by values in binary format.
+    def write_binary_values(self, message, values, datatype='f',
+                            is_big_endian=False, termination=None,
+                            encoding=None):
+        """Write a string message to the device followed by values in binary
+        format.
 
         The write_termination is always appended to it.
 
         :param message: the message to be sent.
         :type message: unicode (Py2) or str (Py3)
         :param values: data to be writen to the device.
-        :param datatype: the format string for a single element. See struct module.
+        :param datatype: the format string for a single element. See struct
+                         module.
         :param is_big_endian: boolean indicating endianess.
         :return: number of bytes written.
         :rtype: int
@@ -277,13 +299,18 @@ class MessageBasedResource(Resource):
         return count
 
     def write_values(self, message, values, termination=None, encoding=None):
-
+        warnings.warn('write_values is deprecated and will be removed in '
+                      '1.10, use write_ascii_values or write_binary_values '
+                      'instead.', DeprecationWarning)
         vf = self.values_format
 
         if vf.is_binary:
-            return self.write_binary_values(message, values, vf.datatype, vf.is_big_endian, termination, encoding)
+            return self.write_binary_values(message, values, vf.datatype,
+                                            vf.is_big_endian, termination,
+                                            encoding)
 
-        return self.write_ascii_values(message, values, vf.converter, vf.separator, termination, encoding)
+        return self.write_ascii_values(message, values, vf.converter,
+                                       vf.separator, termination, encoding)
 
     def read_raw(self, size=None):
         """Read the unmodified string sent from the instrument to the computer.
@@ -296,9 +323,9 @@ class MessageBasedResource(Resource):
 
     def _read_raw(self, size=None):
         """Read the unmodified string sent from the instrument to the computer.
-        
+
         In contrast to read(), no termination characters are stripped.
-        
+
         :rtype: bytearray
         """
         size = self.chunk_size if size is None else size
@@ -306,7 +333,8 @@ class MessageBasedResource(Resource):
         loop_status = constants.StatusCode.success_max_count_read
 
         ret = bytearray()
-        with self.ignore_warning(constants.VI_SUCCESS_DEV_NPRESENT, constants.VI_SUCCESS_MAX_CNT):
+        with self.ignore_warning(constants.VI_SUCCESS_DEV_NPRESENT,
+                                 constants.VI_SUCCESS_MAX_CNT):
             try:
                 status = loop_status
                 while status == loop_status:
@@ -315,8 +343,8 @@ class MessageBasedResource(Resource):
                     chunk, status = self.visalib.read(self.session, size)
                     ret.extend(chunk)
             except errors.VisaIOError as e:
-                logger.debug('%s - exception while reading: %s\nBuffer content: %r',
-                             self._resource_name, e, ret)
+                logger.debug('%s - exception while reading: %s\nBuffer '
+                             'content: %r', self._resource_name, e, ret)
                 raise
 
         return ret
@@ -353,6 +381,75 @@ class MessageBasedResource(Resource):
 
         return message[:-len(termination)]
 
+    def read_ascii_values(self, converter='f', separator=',', container=list,
+                          delay=None):
+        """Read values from the device in ascii format returning an iterable of
+        values.
+
+        :param message: the message to send.
+        :type message: str
+        :param delay: delay in seconds between write and read operations.
+                      if None, defaults to self.query_delay
+        :param converter: function used to convert each element.
+                          Defaults to float
+        :type converter: callable
+        :param separator: a callable that split the str into individual
+                          elements. If a str is given, data.split(separator) is
+                          used.
+        :type: separator: (str) -> collections.Iterable[int] | str
+        :param container: container type to use for the output data.
+        :returns: the answer from the device.
+        :rtype: list
+
+        """
+        block = self.read()
+
+        return util.from_ascii_block(block, converter, separator, container)
+
+    def read_binary_values(self, datatype='f', is_big_endian=False,
+                           container=list, delay=None, header_fmt='ieee'):
+        """Read values from the device in binary format returning an iterable
+        of values.
+
+        :param message: the message to send to the instrument.
+        :param datatype: the format string for a single element. See struct
+                         module.
+        :param is_big_endian: boolean indicating endianess.
+                              Defaults to False.
+        :param container: container type to use for the output data.
+        :param delay: delay in seconds between write and read operations.
+                      if None, defaults to self.query_delay
+        :returns: the answer from the device.
+        :rtype: list
+
+        """
+        block = self._read_raw()
+        expected_length = 0
+
+        if header_fmt == 'ieee':
+            offset, data_length = util.parse_ieee_block_header(block)
+            expected_length = offset + data_length
+        elif header_fmt == 'hp':
+            offset, data_length = util.parse_hp_block_header(block,
+                                                             is_big_endian)
+            expected_length = offset + data_length
+
+        while len(block) < expected_length:
+            block.extend(self._read_raw())
+
+        try:
+            if header_fmt == 'ieee':
+                return util.from_ieee_block(block, datatype, is_big_endian,
+                                            container)
+            elif header_fmt == 'empty':
+                return util.from_binary_block(block, 0, None, datatype,
+                                              is_big_endian, container)
+            elif header_fmt == 'hp':
+                return util.from_binary_block(block, offset, None, datatype,
+                                              is_big_endian, container)
+        except ValueError as e:
+            raise errors.InvalidBinaryFormat(e.args)
+
     def read_values(self, fmt=None, container=list):
         """Read a list of floating point values from the device.
 
@@ -365,13 +462,17 @@ class MessageBasedResource(Resource):
         :return: the list of read values
         :rtype: list
         """
+        warnings.warn('write_values is deprecated and will be removed in '
+                      '1.10, use read_ascii_values or read_binary_values '
+                      'instead.', DeprecationWarning)
         if not fmt:
             vf = self.values_format
             if not vf.is_binary:
                 return util.from_ascii_block(self.read(), container)
             data = self._read_raw()
             try:
-                return util.parse_binary(data, vf.is_big_endian, vf.datatype=='f')
+                return util.parse_binary(data, vf.is_big_endian,
+                                         vf.datatype == 'f')
             except ValueError as e:
                 try:
                     msg = e.args[0]
@@ -379,20 +480,20 @@ class MessageBasedResource(Resource):
                     msg = ''
                 raise errors.InvalidBinaryFormat(msg)
 
-        if fmt & 0x01 == 0: # ascii
+        if fmt & 0x01 == 0:  # ascii
             return util.from_ascii_block(self.read())
 
         data = self._read_raw()
 
         try:
-            if fmt & 0x03 == 1: #single
+            if fmt & 0x03 == 1:  # single
                 is_single = True
-            elif fmt & 0x03 == 3: #double:
+            elif fmt & 0x03 == 3:  # double:
                 is_single = False
             else:
                 raise ValueError("unknown data values fmt requested")
 
-            is_big_endian = fmt & 0x04 # big endian
+            is_big_endian = fmt & 0x04  # big endian
             return util.parse_binary(data, is_big_endian, is_single)
         except ValueError as e:
             raise errors.InvalidBinaryFormat(e.args)
@@ -416,8 +517,10 @@ class MessageBasedResource(Resource):
             time.sleep(delay)
         return self.read()
 
-    # Kept for backwards compatibility.
-    ask = query
+    def ask(self, message, delay=None):
+        warnings.warn('ask is deprecated and will be removed in '
+                      '1.10, use query instead.', DeprecationWarning)
+        return self.query(message, delay)
 
     def query_values(self, message, delay=None):
         """Query the device for values returning an iterable of values.
@@ -431,15 +534,23 @@ class MessageBasedResource(Resource):
         :returns: the answer from the device.
         :rtype: list
         """
+        warnings.warn('query_values is deprecated and will be removed in '
+                      '1.10, use query_ascii_values or quey_binary_values '
+                      'instead.', DeprecationWarning)
         vf = self.values_format
 
         if vf.is_binary:
-            return self.query_binary_values(message, vf.datatype, vf.is_big_endian, vf.container, delay, vf.header_fmt)
+            return self.query_binary_values(message, vf.datatype,
+                                            vf.is_big_endian, vf.container,
+                                            delay, vf.header_fmt)
 
-        return self.query_ascii_values(message, vf.converter, vf.separator, vf.container, delay)
+        return self.query_ascii_values(message, vf.converter, vf.separator,
+                                       vf.container, delay)
 
-    def query_ascii_values(self, message, converter='f', separator=',', container=list, delay=None):
-        """Query the device for values in ascii format returning an iterable of values.
+    def query_ascii_values(self, message, converter='f', separator=',',
+                           container=list, delay=None):
+        """Query the device for values in ascii format returning an iterable of
+        values.
 
         :param message: the message to send.
         :type message: str
@@ -448,8 +559,9 @@ class MessageBasedResource(Resource):
         :param converter: function used to convert each element.
                           Defaults to float
         :type converter: callable
-        :param separator: a callable that split the str into individual elements.
-                          If a str is given, data.split(separator) is used.
+        :param separator: a callable that split the str into individual
+                          elements. If a str is given, data.split(separator) is
+                          used.
         :type: separator: (str) -> collections.Iterable[int] | str
         :param container: container type to use for the output data.
         :returns: the answer from the device.
@@ -462,25 +574,28 @@ class MessageBasedResource(Resource):
         if delay > 0.0:
             time.sleep(delay)
 
-        block = self.read()
+        return self.read_ascii_values(converter, separator, container,
+                                      delay)
 
-        return util.from_ascii_block(block, converter, separator, container)
-
-    def query_binary_values(self, message, datatype='f', is_big_endian=False, container=list, delay=None, header_fmt='ieee'):
-        """Converts an iterable of numbers into a block of data in the ieee format.
+    def query_binary_values(self, message, datatype='f', is_big_endian=False,
+                            container=list, delay=None, header_fmt='ieee'):
+        """Query the device for values in binary format returning an iterable
+        of values.
 
         :param message: the message to send to the instrument.
-        :param datatype: the format string for a single element. See struct module.
+        :param datatype: the format string for a single element. See struct
+                         module.
         :param is_big_endian: boolean indicating endianess.
                               Defaults to False.
         :param container: container type to use for the output data.
         :param delay: delay in seconds between write and read operations.
                       if None, defaults to self.query_delay
-        :rtype: bytes
+        :returns: the answer from the device.
+        :rtype: list
         """
-
         if header_fmt not in ('ieee', 'empty', 'hp'):
-            raise ValueError("Invalid header format. Valid options are 'ieee', 'empty', 'hp'")
+            raise ValueError("Invalid header format. Valid options are 'ieee',"
+                             " 'empty', 'hp'")
 
         self.write(message)
         if delay is None:
@@ -488,29 +603,8 @@ class MessageBasedResource(Resource):
         if delay > 0.0:
             time.sleep(delay)
 
-
-        block = self._read_raw()
-        expected_length = 0
-
-        if header_fmt == 'ieee':
-            offset, data_length = util.parse_ieee_block_header(block)
-            expected_length = offset + data_length
-        elif header_fmt == 'hp':
-            offset, data_length = util.parse_hp_block_header(block, is_big_endian=is_big_endian)
-            expected_length = offset + data_length
-
-        while len(block) < expected_length:
-            block.extend(self._read_raw())
-
-        try:
-            if header_fmt == 'ieee':
-                return util.from_ieee_block(block, datatype, is_big_endian, container)
-            elif header_fmt == 'empty':
-                return util.from_binary_block(block, 0, None, datatype, is_big_endian, container)
-            elif header_fmt == 'hp':
-                return util.from_binary_block(block, offset, None, datatype, is_big_endian, container)
-        except ValueError as e:
-            raise errors.InvalidBinaryFormat(e.args)
+        return self.read_binary_values(datatype, is_big_endian, container,
+                                       delay, header_fmt)
 
     def ask_for_values(self, message, fmt=None, delay=None):
         """A combination of write(message) and read_values()
@@ -522,7 +616,9 @@ class MessageBasedResource(Resource):
         :returns: the answer from the device.
         :rtype: list
         """
-
+        warnings.warn('ask_values is deprecated and will be removed in '
+                      '1.10, use query_ascii_values or quey_binary_values '
+                      'instead.', DeprecationWarning)
         self.write(message)
         if delay is None:
             delay = self.query_delay
@@ -534,7 +630,8 @@ class MessageBasedResource(Resource):
         """Sends a software trigger to the device.
         """
 
-        self.visalib.assert_trigger(self.session, constants.VI_TRIG_PROT_DEFAULT)
+        self.visalib.assert_trigger(self.session,
+                                    constants.VI_TRIG_PROT_DEFAULT)
 
     @property
     def stb(self):
@@ -551,10 +648,12 @@ class MessageBasedResource(Resource):
     @contextlib.contextmanager
     def read_termination_context(self, new_termination):
         term = self.get_visa_attribute(constants.VI_ATTR_TERMCHAR)
-        self.set_visa_attribute(constants.VI_ATTR_TERMCHAR, ord(new_termination[-1]))
+        self.set_visa_attribute(constants.VI_ATTR_TERMCHAR,
+                                ord(new_termination[-1]))
         yield
         self.set_visa_attribute(constants.VI_ATTR_TERMCHAR, term)
 
 
 # Rohde and Schwarz Device via Passport. Not sure which Resource should be.
-MessageBasedResource.register(constants.InterfaceType.rsnrp, 'INSTR')(MessageBasedResource)
+MessageBasedResource.register(constants.InterfaceType.rsnrp,
+                              'INSTR')(MessageBasedResource)

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -429,8 +429,6 @@ class MessageBasedResource(Resource):
         """Read values from the device in ascii format returning an iterable of
         values.
 
-        :param message: the message to send.
-        :type message: str
         :param delay: delay in seconds between write and read operations.
                       if None, defaults to self.query_delay
         :param converter: function used to convert each element.
@@ -455,7 +453,6 @@ class MessageBasedResource(Resource):
         """Read values from the device in binary format returning an iterable
         of values.
 
-        :param message: the message to send to the instrument.
         :param datatype: the format string for a single element. See struct
                          module.
         :param is_big_endian: boolean indicating endianess.

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -488,14 +488,19 @@ class MessageBasedResource(Resource):
         if delay > 0.0:
             time.sleep(delay)
 
+
         block = self._read_raw()
+        expected_length = 0
 
         if header_fmt == 'ieee':
             offset, data_length = util.parse_ieee_block_header(block)
             expected_length = offset + data_length
+        elif header_fmt == 'hp':
+            offset, data_length = util.parse_hp_block_header(block, is_big_endian=is_big_endian)
+            expected_length = offset + data_length
 
-            while len(block) < expected_length:
-                block.extend(self._read_raw())
+        while len(block) < expected_length:
+            block.extend(self._read_raw())
 
         try:
             if header_fmt == 'ieee':
@@ -503,7 +508,7 @@ class MessageBasedResource(Resource):
             elif header_fmt == 'empty':
                 return util.from_binary_block(block, 0, None, datatype, is_big_endian, container)
             elif header_fmt == 'hp':
-                return util.from_binary_block(block, 4, None, datatype, is_big_endian, container)
+                return util.from_binary_block(block, offset, None, datatype, is_big_endian, container)
         except ValueError as e:
             raise errors.InvalidBinaryFormat(e.args)
 

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -254,7 +254,7 @@ class MessageBasedResource(Resource):
 
         block = util.to_ascii_block(values, converter, separator)
 
-        message = message.encode(enco) + block.encode(enco)
+        message = message.encode(enco) + block
 
         if term:
             message += term.encode(enco)
@@ -402,6 +402,7 @@ class MessageBasedResource(Resource):
         :rtype: list
 
         """
+        # Use read rather than _read_raw because we cannot handle a bytearray
         block = self.read()
 
         return util.from_ascii_block(block, converter, separator, container)
@@ -606,7 +607,7 @@ class MessageBasedResource(Resource):
             time.sleep(delay)
 
         return self.read_binary_values(datatype, is_big_endian, container,
-                                       delay, header_fmt)
+                                       header_fmt)
 
     def ask_for_values(self, message, fmt=None, delay=None):
         """A combination of write(message) and read_values()

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -103,13 +103,13 @@ class MessageBasedResource(Resource):
     @property
     def values_format(self):
         warnings.warn('values_format is deprecated and will be removed in '
-                      '1.10', DeprecationWarning)
+                      '1.10', FutureWarning)
         return self._values_format
 
     @values_format.setter
     def values_format(self, fmt):
         warnings.warn('values_format is deprecated and will be removed in '
-                      '1.10', DeprecationWarning)
+                      '1.10', FutureWarning)
         self._values_format.is_binary = not (fmt & 0x01 == 0)
         if fmt & 0x03 == 1:  # single
             self._values_format.datatype = 'f'
@@ -127,13 +127,13 @@ class MessageBasedResource(Resource):
         """An alias for query_delay kept for backwards compatibility.
         """
         warnings.warn('ask_delay is deprecated and will be removed in '
-                      '1.10, use query_delay instead', DeprecationWarning)
+                      '1.10, use query_delay instead', FutureWarning)
         return self.query_delay
 
     @ask_delay.setter
     def ask_delay(self, value):
         warnings.warn('ask_delay is deprecated and will be removed in '
-                      '1.10, use query_delay instead', DeprecationWarning)
+                      '1.10, use query_delay instead', FutureWarning)
         self.query_delay = value
 
     @property
@@ -301,7 +301,7 @@ class MessageBasedResource(Resource):
     def write_values(self, message, values, termination=None, encoding=None):
         warnings.warn('write_values is deprecated and will be removed in '
                       '1.10, use write_ascii_values or write_binary_values '
-                      'instead.', DeprecationWarning)
+                      'instead.', FutureWarning)
         vf = self.values_format
 
         if vf.is_binary:
@@ -464,7 +464,7 @@ class MessageBasedResource(Resource):
         """
         warnings.warn('write_values is deprecated and will be removed in '
                       '1.10, use read_ascii_values or read_binary_values '
-                      'instead.', DeprecationWarning)
+                      'instead.', FutureWarning)
         if not fmt:
             vf = self.values_format
             if not vf.is_binary:
@@ -519,7 +519,7 @@ class MessageBasedResource(Resource):
 
     def ask(self, message, delay=None):
         warnings.warn('ask is deprecated and will be removed in '
-                      '1.10, use query instead.', DeprecationWarning)
+                      '1.10, use query instead.', FutureWarning)
         return self.query(message, delay)
 
     def query_values(self, message, delay=None):
@@ -536,7 +536,7 @@ class MessageBasedResource(Resource):
         """
         warnings.warn('query_values is deprecated and will be removed in '
                       '1.10, use query_ascii_values or quey_binary_values '
-                      'instead.', DeprecationWarning)
+                      'instead.', FutureWarning)
         vf = self.values_format
 
         if vf.is_binary:
@@ -618,7 +618,7 @@ class MessageBasedResource(Resource):
         """
         warnings.warn('ask_values is deprecated and will be removed in '
                       '1.10, use query_ascii_values or quey_binary_values '
-                      'instead.', DeprecationWarning)
+                      'instead.', FutureWarning)
         self.write(message)
         if delay is None:
             delay = self.query_delay

--- a/pyvisa/testsuite/__init__.py
+++ b/pyvisa/testsuite/__init__.py
@@ -6,12 +6,13 @@ from __future__ import (division, unicode_literals, print_function,
 import os
 import logging
 import warnings
+import unittest
 from contextlib import contextmanager
 
 from logging.handlers import BufferingHandler
 
 from pyvisa import logger
-from pyvisa.compat import unittest, PYTHON3
+from pyvisa.compat import PYTHON3
 
 
 class TestHandler(BufferingHandler):

--- a/pyvisa/testsuite/__init__.py
+++ b/pyvisa/testsuite/__init__.py
@@ -5,12 +5,13 @@ from __future__ import (division, unicode_literals, print_function,
 
 import os
 import logging
+import warnings
 from contextlib import contextmanager
 
 from logging.handlers import BufferingHandler
 
 from pyvisa import logger
-from pyvisa.compat import unittest
+from pyvisa.compat import unittest, PYTHON3
 
 
 class TestHandler(BufferingHandler):
@@ -62,6 +63,21 @@ class BaseTestCase(unittest.TestCase):
             l = len(buf)
             msg = '\n'.join(record.get('msg', str(record)) for record in buf)
             self.assertEqual(l, 0, msg='%d warnings raised.\n%s' % (l, msg))
+
+    if not PYTHON3:
+        @contextmanager
+        def assertWarns(self, category):
+            """Backport for Python 2
+
+            """
+            with warnings.catch_warnings(record=True) as w:
+                # Cause all warnings to always be triggered.
+                warnings.simplefilter("always")
+                # Trigger a warning.
+                yield
+                # Verify some things
+                assert len(w) == 1, 'No warning raised'
+                assert issubclass(w[-1].category, category)
 
 
 def testsuite():

--- a/pyvisa/testsuite/__init__.py
+++ b/pyvisa/testsuite/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 import os
 import logging
@@ -85,4 +86,3 @@ def run():
     """
     test_runner = unittest.TextTestRunner()
     return test_runner.run(testsuite())
-

--- a/pyvisa/testsuite/test_rname.py
+++ b/pyvisa/testsuite/test_rname.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
-from pyvisa.compat import unittest
+import unittest
 from pyvisa.testsuite import BaseTestCase
 
 from pyvisa import rname

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division, unicode_literals, print_function, absolute_import
+from __future__ import (division, unicode_literals, print_function,
+                        absolute_import)
 
 from pyvisa.testsuite import BaseTestCase
 
@@ -12,11 +13,13 @@ try:
 except ImportError:
     np = None
 
+
 class TestParser(BaseTestCase):
 
     def test_parse_binary(self):
-        s = b'#A@\xe2\x8b<@\xe2\x8b<@\xe2\x8b<@\xe2\x8b<@\xde\x8b<@\xde\x8b<@\xde\x8b<' \
-            b'@\xde\x8b<@\xe0\x8b<@\xe0\x8b<@\xdc\x8b<@\xde\x8b<@\xe2\x8b<@\xe0\x8b<'
+        s = (b'#A@\xe2\x8b<@\xe2\x8b<@\xe2\x8b<@\xe2\x8b<@\xde\x8b<@\xde\x8b<@'
+             b'\xde\x8b<@\xde\x8b<@\xe0\x8b<@\xe0\x8b<@\xdc\x8b<@\xde\x8b<@'
+             b'\xe2\x8b<@\xe0\x8b<')
         e = [0.01707566, 0.01707566, 0.01707566, 0.01707566, 0.01707375,
              0.01707375, 0.01707375, 0.01707375, 0.01707470, 0.01707470,
              0.01707280, 0.01707375, 0.01707566, 0.01707470]
@@ -29,7 +32,7 @@ class TestParser(BaseTestCase):
 
     def test_ieee_integer(self):
         values = list(range(99))
-        containers = (list, tuple) #+ ((np.asarray,) if np else ())
+        containers = (list, tuple) + ((np.array,) if np else ())
         for fmt in 'bBhHiIfd':
             for endi in (True, False):
                 for cont in containers:
@@ -45,7 +48,7 @@ class TestParser(BaseTestCase):
 
     def test_ieee_noninteger(self):
         values = [val + 0.5 for val in range(99)]
-        containers = (list, tuple) #+ ((np.asarray,) if np else ())
+        containers = (list, tuple) + ((np.array,) if np else ())
         for fmt in 'fd':
             for endi in (True, False):
                 for cont in containers:

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -88,7 +88,7 @@ class TestParser(BaseTestCase):
                 for endi in (True, False):
                     msg = 'block=%s, fmt=%s, endianness=%s'
                     msg = msg % (block, fmt, endi)
-                    tblock = lambda values: tb(values, fmt, endi)
+                    tblock = lambda values: bytearray(tb(values, fmt, endi))
                     fblock = lambda block, cont: fb(block, fmt, endi, cont)
                     self.round_trip_block_converstion(values, tblock, fblock,
                                                       msg)

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -23,41 +23,92 @@ class TestParser(BaseTestCase):
         e = [0.01707566, 0.01707566, 0.01707566, 0.01707566, 0.01707375,
              0.01707375, 0.01707375, 0.01707375, 0.01707470, 0.01707470,
              0.01707280, 0.01707375, 0.01707566, 0.01707470]
-        p = util.parse_binary(s, is_big_endian=False, is_single=True)
+        with self.assertWarns(FutureWarning):
+            p = util.parse_binary(s, is_big_endian=False, is_single=True)
         for a, b in zip(p, e):
             self.assertAlmostEqual(a, b)
+
+        # Test handling indefinite length block
         p = util.from_ieee_block(s, datatype='f', is_big_endian=False)
         for a, b in zip(p, e):
             self.assertAlmostEqual(a, b)
 
-    def test_ieee_integer(self):
+        # Test handling definite length block
+        p = util.from_ieee_block(b'#214' + s[2:], datatype='f',
+                                 is_big_endian=False)
+        for a, b in zip(p, e):
+            self.assertAlmostEqual(a, b)
+
+        p = util.from_hp_block(b'#A\x0e\x00' + s[2:], datatype='f',
+                               is_big_endian=False)
+        for a, b in zip(p, e):
+            self.assertAlmostEqual(a, b)
+
+    def test_integer_ascii_block(self):
         values = list(range(99))
-        containers = (list, tuple) + ((np.array,) if np else ())
-        for fmt in 'bBhHiIfd':
-            for endi in (True, False):
-                for cont in containers:
-                    conv = cont(values)
-                    msg = 'fmt=%s, endianness=%s, container=%s' % (fmt, endi, cont.__name__)
-                    try:
-                        block = util.to_ieee_block(conv, fmt, endi)
-                        parsed = util.from_ieee_block(block, fmt, endi, cont)
-                    except Exception as e:
-                        raise Exception(msg + '\n' + repr(e))
+        for fmt in 'd':
+            msg = 'block=%s, fmt=%s'
+            msg = msg % ('ascii', fmt)
+            tb = lambda values: util.to_ascii_block(values, fmt, ',')
+            fb = lambda block, cont: util.from_ascii_block(block, fmt, ',',
+                                                           cont)
+            self.round_trip_block_converstion(values, tb, fb, msg)
 
-                    self.assertEqual(conv, parsed, msg)
-
-    def test_ieee_noninteger(self):
+    def test_non_integer_ascii_block(self):
         values = [val + 0.5 for val in range(99)]
-        containers = (list, tuple) + ((np.array,) if np else ())
-        for fmt in 'fd':
-            for endi in (True, False):
-                for cont in containers:
-                    conv = cont(values)
-                    msg = 'fmt=%s, endianness=%s, container=%s' % (fmt, endi, cont.__name__)
-                    try:
-                        block = util.to_ieee_block(conv, fmt, endi)
-                        parsed = util.from_ieee_block(block, fmt, endi, cont)
-                    except Exception as e:
-                        raise Exception(msg + '\n' + repr(e))
+        values = list(range(99))
+        for fmt in 'fFeEgG':
+            msg = 'block=%s, fmt=%s'
+            msg = msg % ('ascii', fmt)
+            tb = lambda values: util.to_ascii_block(values, fmt, ',')
+            fb = lambda block, cont: util.from_ascii_block(block, fmt, ',',
+                                                           cont)
+            self.round_trip_block_converstion(values, tb, fb, msg)
 
-                    self.assertEqual(conv, parsed, msg)
+    def test_integer_binary_block(self):
+        values = list(range(99))
+        for block, tb, fb in zip(('ieee', 'hp'),
+                                 (util.to_ieee_block, util.to_hp_block),
+                                 (util.from_ieee_block, util.from_hp_block)):
+            for fmt in 'bBhHiIfd':
+                for endi in (True, False):
+                    msg = 'block=%s, fmt=%s, endianness=%s'
+                    msg = msg % (block, fmt, endi)
+                    tblock = lambda values: tb(values, fmt, endi)
+                    fblock = lambda block, cont: fb(block, fmt, endi, cont)
+                    self.round_trip_block_converstion(values, tblock, fblock,
+                                                      msg)
+
+    def test_noninteger_binary_block(self):
+        values = [val + 0.5 for val in range(99)]
+        for block, tb, fb in zip(('ieee', 'hp'),
+                                 (util.to_ieee_block, util.to_hp_block),
+                                 (util.from_ieee_block, util.from_hp_block)):
+            for fmt in 'fd':
+                for endi in (True, False):
+                    msg = 'block=%s, fmt=%s, endianness=%s'
+                    msg = msg % (block, fmt, endi)
+                    tblock = lambda values: tb(values, fmt, endi)
+                    fblock = lambda block, cont: fb(block, fmt, endi, cont)
+                    self.round_trip_block_converstion(values, tblock, fblock,
+                                                      msg)
+
+    def round_trip_block_converstion(self, values, to_block, from_block, msg):
+        """Test that block conversion round trip as expected.
+
+        """
+        containers = (list, tuple) + ((np.array,) if np else ())
+        for cont in containers:
+            conv = cont(values)
+            msg += ', container=%s'
+            msg = msg % cont.__name__
+            try:
+                block = to_block(conv)
+                parsed = from_block(block, cont)
+            except Exception as e:
+                raise Exception(msg + '\n' + repr(e))
+
+            if np and cont in (np.array,):
+                np.testing.assert_array_equal(conv, parsed, msg)
+            else:
+                self.assertEqual(conv, parsed, msg)

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -22,8 +22,9 @@ import sys
 import subprocess
 import warnings
 import inspect
+from subprocess import check_output
 
-from .compat import (check_output, string_types, OrderedDict, struct,
+from .compat import (string_types, OrderedDict, struct,
                      int_to_bytes, int_from_bytes, PYTHON3)
 from . import __version__, logger
 

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -208,6 +208,8 @@ def to_ascii_block(iterable, converter='f', separator=','):
     :param separator: a callable that split the str into individual elements.
                       If a str is given, data.split(separator) is used.
     :type: separator: (collections.Iterable[T]) -> str | str
+
+    :rtype: bytes
     """
 
     if isinstance(separator, string_types):
@@ -215,9 +217,10 @@ def to_ascii_block(iterable, converter='f', separator=','):
 
     if isinstance(converter, string_types):
         converter = '%' + converter
-        return separator(converter % val for val in iterable)
+        block = separator(converter % val for val in iterable)
     else:
-        return separator(converter(val) for val in iterable)
+        block = separator(converter(val) for val in iterable)
+    return block.encode('ascii')
 
 
 def parse_binary(bytes_data, is_big_endian=False, is_single=False):

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -187,7 +187,7 @@ _np_converters = {
     'G': 'f',
 }
 
-# XXX make thing homogeneous in term of bytes vs str
+
 def from_ascii_block(ascii_data, converter='f', separator=',', container=list):
     """Parse ascii data and return an iterable of numbers.
 
@@ -236,7 +236,7 @@ def to_ascii_block(iterable, converter='f', separator=','):
                       If a str is given, data.split(separator) is used.
     :type: separator: (collections.Iterable[T]) -> str | str
 
-    :rtype: bytes
+    :rtype: str
     """
 
     if isinstance(separator, string_types):
@@ -247,7 +247,7 @@ def to_ascii_block(iterable, converter='f', separator=','):
         block = separator(converter % val for val in iterable)
     else:
         block = separator(converter(val) for val in iterable)
-    return block.encode('ascii')
+    return block
 
 
 def parse_binary(bytes_data, is_big_endian=False, is_single=False):

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -23,7 +23,8 @@ import subprocess
 import warnings
 import inspect
 
-from .compat import check_output, string_types, OrderedDict, struct
+from .compat import (check_output, string_types, OrderedDict, struct,
+                     int_to_bytes, int_from_bytes)
 from . import __version__, logger
 
 
@@ -367,7 +368,7 @@ def parse_hp_block_header(block, is_big_endian):
                          "indicating the start of the block.")
     offset = begin + 4
 
-    data_length = int.from_bytes(block[begin+2:offset],
+    data_length = int_from_bytes(block[begin+2:offset],
                                  byteorder='big' if is_big_endian else 'little'
                                  )
 
@@ -507,8 +508,8 @@ def to_hp_block(iterable, datatype='f', is_big_endian=False):
     element_length = struct.calcsize(datatype)
     data_length = array_length * element_length
 
-    header = b'#A' + (data_length.to_bytes(2, 'big' if is_big_endian
-                                           else 'little'))
+    header = b'#A' + (int_to_bytes(data_length, 2,
+                                   'big' if is_big_endian else 'little'))
 
     endianess = '>' if is_big_endian else '<'
     fullfmt = '%s%d%s' % (endianess, array_length, datatype)

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -296,6 +296,29 @@ def parse_ieee_block_header(block):
 
     return offset, data_length
 
+def parse_hp_block_header(block, is_big_endian):
+    """Parse the header of a HP block.
+
+    Definite Length Arbitrary Block:
+    #A<data_length><data>
+
+    The header ia always 4 bytes long.
+    The data_length field specifies the size of the data.
+
+    :param block: HP block.
+    :type block: bytes
+    :param is_big_endian: boolean indicating endianess.
+    :return: (offset, data_length)
+    :rtype: (int, int)
+    """
+    begin  = block.find(b'#A')
+    if begin < 0:
+        raise ValueError("Could not find the standard block header (#A) indicating the start of the block.")
+    offset = begin + 4
+
+    data_length = int.from_bytes(block[begin+2:offset], byteorder='big' if is_big_endian else 'little')
+
+    return offset, data_length
 
 def from_ieee_block(block, datatype='f', is_big_endian=False, container=list):
     """Convert a block in the IEEE format into an iterable of numbers.

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -298,7 +298,8 @@ def parse_binary(bytes_data, is_big_endian=False, is_single=False):
         else:
             fmt = endianess + str(data_length // 8) + 'd'
 
-        result = list(struct.unpack(fmt, data))
+        # Python 2.6 compatibility make sure fmt is str not unicode
+        result = list(struct.unpack(str(fmt), data))
     except struct.error:
         raise ValueError("Binary data itself was malformed")
 

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -299,8 +299,7 @@ def parse_binary(bytes_data, is_big_endian=False, is_single=False):
         else:
             fmt = endianess + str(data_length // 8) + 'd'
 
-        # Python 2.6 compatibility make sure fmt is str not unicode
-        result = list(struct.unpack(str(fmt), data))
+        result = list(struct.unpack(fmt, data))
     except struct.error:
         raise ValueError("Binary data itself was malformed")
 

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -187,7 +187,7 @@ _np_converters = {
     'G': 'f',
 }
 
-
+# XXX make thing homogeneous in term of bytes vs str
 def from_ascii_block(ascii_data, converter='f', separator=',', container=list):
     """Parse ascii data and return an iterable of numbers.
 
@@ -236,7 +236,7 @@ def to_ascii_block(iterable, converter='f', separator=','):
                       If a str is given, data.split(separator) is used.
     :type: separator: (collections.Iterable[T]) -> str | str
 
-    :rtype: str
+    :rtype: bytes
     """
 
     if isinstance(separator, string_types):
@@ -247,7 +247,7 @@ def to_ascii_block(iterable, converter='f', separator=','):
         block = separator(converter % val for val in iterable)
     else:
         block = separator(converter(val) for val in iterable)
-    return block
+    return block.encode('ascii')
 
 
 def parse_binary(bytes_data, is_big_endian=False, is_single=False):
@@ -459,7 +459,7 @@ def from_binary_block(block, offset=0, data_length=None, datatype='f',
     endianess = '>' if is_big_endian else '<'
 
     if _use_numpy_routines(container):
-        return np.fromstring(block[offset:], endianess+datatype, array_length)
+        return np.frombuffer(block, endianess+datatype, array_length, offset)
 
     fullfmt = '%s%d%s' % (endianess, array_length, datatype)
 
@@ -468,6 +468,7 @@ def from_binary_block(block, offset=0, data_length=None, datatype='f',
     except struct.error:
         raise ValueError("Binary data was malformed")
 
+# XXX refactor to avoid duplication
 
 def to_ieee_block(iterable, datatype='f', is_big_endian=False):
     """Convert an iterable of numbers into a block of data in the IEEE format.


### PR DESCRIPTION
~~This is WIP and untested so far~~ This has now been fully tested locally:
- implement HP binary header following @thliebig work ~~(I plan on adding tests)~~ done
- fix the issue in write_ascii_values by properly encoding the values in `utils.to_ascii_block` (closes #252)
- add noisy warnings to encourage migrations to new api for values reading/writing
- uniformize the API for reading values by providing read_ascii_values and read_binary_values

Also make all file concerned by the update be PEP8 compliant.

I hope to complete and test this before Christmas, but anybody is welcome to test and review.
