### PR TITLE
Prefer import to pkgutil.iter_modules(), support PyInstaller

### DIFF
--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -1445,14 +1445,6 @@ def get_wrapper_class(backend_name):
     except ImportError:
         raise ValueError('Wrapper not found: No package named pyvisa-%s' % backend_name)
 
-#    for pkgname in list_backends():
-#        if pkgname.endswith('-' + backend_name):
-#            pkg = __import__(pkgname)
-#            _WRAPPERS[backend_name] = cls = pkg.WRAPPER_CLASS
-#            return cls
-#    else:
-#        raise ValueError('Wrapper not found: No package named pyvisa-%s' % backend_name)
-
 
 def open_visa_library(specification):
     """Helper function to create a VISA library wrapper.

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -1438,13 +1438,20 @@ def get_wrapper_class(backend_name):
             _WRAPPERS['ni'] = NIVisaLibrary
             return NIVisaLibrary
 
-    for pkgname in list_backends():
-        if pkgname.endswith('-' + backend_name):
-            pkg = __import__(pkgname)
-            _WRAPPERS[backend_name] = cls = pkg.WRAPPER_CLASS
-            return cls
-    else:
+    try:
+        pkg = __import__('pyvisa-' + backend_name)
+        _WRAPPERS[backend_name] = cls = pkg.WRAPPER_CLASS
+        return cls
+    except ImportError:
         raise ValueError('Wrapper not found: No package named pyvisa-%s' % backend_name)
+
+#    for pkgname in list_backends():
+#        if pkgname.endswith('-' + backend_name):
+#            pkg = __import__(pkgname)
+#            _WRAPPERS[backend_name] = cls = pkg.WRAPPER_CLASS
+#            return cls
+#    else:
+#        raise ValueError('Wrapper not found: No package named pyvisa-%s' % backend_name)
 
 
 def open_visa_library(specification):


### PR DESCRIPTION
`pyvisa.highlevel.get_wrapper_class` iterates through the discovered backends to find one that matches the requested name. This iteration is performed in `list_backends()` and uses `pkgutil.iter_modules()`. If a backend with the matching name is found, the code attempts to dynamically import it.

When PyInstaller "freezes" modules, they can't be found by `pkgutil` and friends, which means that even if you freeze pyvisa and pyvisa-py, the pyvisa-py backend can't be found because `iter_modules` can't see it.

This PR eliminates the search loop, which might not have been strictly necessary. It simply attempts to do the dynamic import. Success and failure are both handled identically to the previous version, but failure is observed when an ImportError is raised.

As a result, PyInstaller can now package up single executables containing pyvisa and pyvisa-py!

Note: `pyvisa.highlevel.list_backends()` still uses pkgutil, which will misreport inside of PyInstaller environments. PyInstaller has a long-term bug to provide their own Importer that knows how to work with pkgutil, but in the short term, this PR seems like an improvement.