### PR TITLE
Added message-length-reached check to _read_raw()

### DIFF
--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -314,6 +314,8 @@ class MessageBasedResource(Resource):
                                  self._resource_name, size, status)
                     chunk, status = self.visalib.read(self.session, size)
                     ret.extend(chunk)
+                    if len(ret) >= size:
+                        break
             except errors.VisaIOError as e:
                 logger.debug('%s - exception while reading: %s\nBuffer content: %r',
                              self._resource_name, e, ret)


### PR DESCRIPTION
When using pyvisa-py as a backend and a TCPIP/Socket attached
instrument, the read_raw(N) function would throw error due to "timeout
reached", even though N or more bytes were read into the buffer.

Thus, to prevent the timeout error, _read_raw(N) does not call the
underlying read function anymore as soon as N or more bytes were
received.