### PR TITLE
rname: fix default gpib secondary address

### DIFF
--- a/pyvisa/rname.py
+++ b/pyvisa/rname.py
@@ -345,9 +345,11 @@ def build_rn_class(interface_type, resource_parts, resource_class,
 
 # Build subclasses for each resource
 
+# Reference for the GPIB secondary address
+# https://www.mathworks.com/help/instrument/secondaryaddress.html
 GPIBInstr = build_rn_class('GPIB',
                            (('board', '0'), ('primary address', None),
-                            ('secondary address', constants.VI_NO_SEC_ADDR)),
+                            ('secondary address', '0')),
                            'INSTR')
 
 GPIBIntfc = build_rn_class('GPIB', (('board', '0'), ), 'INTFC', False)

--- a/pyvisa/testsuite/test_rname.py
+++ b/pyvisa/testsuite/test_rname.py
@@ -41,13 +41,13 @@ class TestParsers(BaseTestCase):
                          canonical_resource_name='ASRL1::INSTR')
 
     def test_gpib_instr(self):
-        self._parse_test('GPIB::1::0::INSTR',
+        self._parse_test('GPIB::1::1::INSTR',
                          interface_type='GPIB',
                          resource_class='INSTR',
                          board='0',
                          primary_address='1',
-                         secondary_address='0',
-                         canonical_resource_name='GPIB0::1::0::INSTR')
+                         secondary_address='1',
+                         canonical_resource_name='GPIB0::1::1::INSTR')
 
         self._parse_test('GPIB::1::INSTR',
                          interface_type='GPIB',

--- a/pyvisa/testsuite/test_rname.py
+++ b/pyvisa/testsuite/test_rname.py
@@ -54,24 +54,24 @@ class TestParsers(BaseTestCase):
                          resource_class='INSTR',
                          board='0',
                          primary_address='1',
-                         secondary_address=65535,
-                         canonical_resource_name='GPIB0::1::65535::INSTR')
+                         secondary_address='0',
+                         canonical_resource_name='GPIB0::1::0::INSTR')
 
         self._parse_test('GPIB1::1::INSTR',
                          interface_type='GPIB',
                          resource_class='INSTR',
                          board='1',
                          primary_address='1',
-                         secondary_address=65535,
-                         canonical_resource_name='GPIB1::1::65535::INSTR')
+                         secondary_address='0',
+                         canonical_resource_name='GPIB1::1::0::INSTR')
 
         self._parse_test('GPIB1::1',
                          interface_type='GPIB',
                          resource_class='INSTR',
                          board='1',
                          primary_address='1',
-                         secondary_address=65535,
-                         canonical_resource_name='GPIB1::1::65535::INSTR')
+                         secondary_address='0',
+                         canonical_resource_name='GPIB1::1::0::INSTR')
 
     def test_gpib_intf(self):
         self._parse_test('GPIB::INTFC',


### PR DESCRIPTION
The documented value in the header is \xFFFF but used in resource string it does crash. The Matworks link suggest using 0 in the absence of secondary address which works (tested on one instrument) and seems more logical.