### PR TITLE
For default backend, use pyvisa-py if the NI binary cannot be found.

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -3,15 +3,15 @@
 Configuring the backend
 ============================
 
-Currently there are two backends available: The one included in pyvisa which
-uses the NI library. This is used by default and the configuration is described
-in the next chapter.
-And then there is pyvisa-py a pure python implementation of the VISA libary.
-It can be selected by passing a parameter to the ResourceManager:
+Currently there are two backends available: The one included in pyvisa, which
+uses the NI library, and the backend provided by pyvisa-py, which is a pure python implementation of the VISA library.
+If no backend is specified, pyvisa uses the NI backend if the NI library has been installed (see next section for details). Failing that, it uses the pyvisa-py backend.
+
+You can also select a desired backend by passing a parameter to the ResourceManager, shown here for pyvisa-py:
 
     >>> visa.ResourceManager('@py')
 
-Alternativly it can also be selected by setting the environment variable
+Alternatively it can also be selected by setting the environment variable
 PYVISA_LIBRARY. It takes the same values as the ResourceManager constructor.
 
 Configuring the NI backend


### PR DESCRIPTION
This fixes #334.

I also have a commit prepared that adds `pyvisa-py` as a dependency to setup.py, but I don't know if you want that. If we include it, it's guaranteed that people will always have a backend available even if the NI one isn't installed, so i lean towards doing that. Please comment on that @MatthieuDartiailh (*edit: I have pushed that commit to the PR now, it should be easy to not included it if desired*)

I tested this on my local machine (without the NI library). pyvisa-py gets selected successfully:

```
import pyvisa
pyvisa.ResourceManager()
Out[2]: <ResourceManager(<VisaLibrary('unset')>)>
```

If neither NI nor pyvisa-py are around, we get (with debug output enabled)
```
pyvisa.ResourceManager()
DEBUG:pyvisa:No visa library specified, trying to find alternatives.
DEBUG:pyvisa:Environment variable PYVISA_LIBRARY is unset.
DEBUG:pyvisa:No user defined library files
DEBUG:pyvisa:Automatically found library files: []
DEBUG:pyvisa:Did not find NI binary
DEBUG:pyvisa:Did not find pyvisa-py package
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<snip>
ValueError: Could not locate a VISA implementation. Install either the NI binary or pyvisa-py.
```