### PR TITLE
Added possibility to redirect logging to file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ PyVISA Changelog
 
 - fixing missing argument for USBInstrument.usb_control_out PR #353
 - usb_control_out -> control_out. warnings for deprecated usb_control_out PR #353
+- added new function log_to_stream() PR #363
 
 
 1.9.1 (2018-08-13)

--- a/pyvisa/__init__.py
+++ b/pyvisa/__init__.py
@@ -23,8 +23,11 @@ logger.addHandler(compat.NullHandler())
 
 
 def log_to_screen(level=logging.DEBUG):
+    log(None, level) # sys.stderr by default
+
+def log(stream_output, level=logging.DEBUG):
     logger.setLevel(level)
-    ch = logging.StreamHandler()
+    ch = logging.StreamHandler(stream_output)
     ch.setLevel(level)
 
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')

--- a/pyvisa/__init__.py
+++ b/pyvisa/__init__.py
@@ -23,9 +23,9 @@ logger.addHandler(compat.NullHandler())
 
 
 def log_to_screen(level=logging.DEBUG):
-    log(None, level) # sys.stderr by default
+    log_to_stream(None, level) # sys.stderr by default
 
-def log(stream_output, level=logging.DEBUG):
+def log_to_stream(stream_output, level=logging.DEBUG):
     logger.setLevel(level)
     ch = logging.StreamHandler(stream_output)
     ch.setLevel(level)


### PR DESCRIPTION
Without breaking compatibility with older code I have kept the log_to_screen() function and added a more generic log() function to be able to redirect the specific pyvisa logging output to file (in the case an application is already using stderr for other purposes).