### PR TITLE
Use ni backend when specifying a file in open_visa_library

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ PyVISA Changelog
 - added new function log_to_stream() PR #363
 - Made all enumerations of the `constants` module unique. 
   Fixed duplicate enums in StatusCode PR #371
+- Use ni backend when specifying a file in open_visa_library PR #373
 
 
 1.9.1 (2018-08-13)

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -1490,7 +1490,10 @@ def open_visa_library(specification):
         argument = specification
         wrapper = None  # Flag that we need a fallback, but avoid nested exceptions
     if wrapper is None:
-        wrapper = _get_default_wrapper()
+        if argument: # some filename given
+            wrapper = 'ni'
+        else:
+            wrapper = _get_default_wrapper()
 
     cls = get_wrapper_class(wrapper)
 


### PR DESCRIPTION
The changes (commit f2d69892) in open_visa_library to use either a NI backend or if not available the pyvisa-py are nice except they seem a bit too broad.

If somebody specifies a file (dll) to use when opening the ResourceManager, it still looks for the standard dll to see if they are available (_get_default_wrapper()). Therefore, if none of the standard dll are available (like visa32.dll, visa64.dll on windows) but a correct other dll is given (like agvisa32.dll for the agilent visa library) it still fails.
It is probably a rare condition to be in but it is not impossible.

This PR fixes that.