### PR TITLE
ctwrapper: use context manager to open (and close) pipes

### DIFF
--- a/pyvisa/ctwrapper/cthelper.py
+++ b/pyvisa/ctwrapper/cthelper.py
@@ -62,12 +62,13 @@ if _os.name == "posix" and _sys.platform.startswith('linux'):
         def _findlib_ldconfig(name):
             # XXX assuming GLIBC's ldconfig (with option -p)
             expr = r'/[^\(\)\s]*lib%s\.[^\(\)\s]*' % re.escape(name)
-            res = re.search(expr,
-                            _os.popen('/sbin/ldconfig -p 2>/dev/null').read())
+            with _os.popen('/sbin/ldconfig -p 2>/dev/null') as pipe:
+                res = re.search(expr, pipe.read())
             if not res:
                 # Hm, this works only for libs needed by the python executable.
                 cmd = 'ldd %s 2>/dev/null' % _sys.executable
-                res = re.search(expr, _os.popen(cmd).read())
+                with _os.popen(cmd) as pipe:
+                    res = re.search(expr, pipe.read())
                 if not res:
                     return None
             return res.group(0)


### PR DESCRIPTION
If the pipes are left open when trying to find the *visa* library paths, we get a lot of exceptions on Linux similar to this:

```
/usr/local/lib/python3.6/subprocess.py:766: ResourceWarning: subprocess 2020 is still running
  ResourceWarning, source=self)
/home/.../.venv/lib/python3.6/site-packages/pyvisa/ctwrapper/cthelper.py:68: ResourceWarning: unclosed file <_io.TextIOWrapper name=34 encoding='UTF-8'>
  _os.popen('/sbin/ldconfig -p 2>/dev/null').read())
/usr/local/lib/python3.6/subprocess.py:766: ResourceWarning: subprocess 2022 is still running
  ResourceWarning, source=self)
/home/.../.venv/lib/python3.6/site-packages/pyvisa/ctwrapper/cthelper.py:74: ResourceWarning: unclosed file <_io.TextIOWrapper name=34 encoding='UTF-8'>
  res = re.search(expr, _os.popen(cmd).read())
```

By using the provided context manager this can be prevented.