### PR TITLE
Add basic support for asynchronous reads

### DIFF
--- a/pyvisa/attributes.py
+++ b/pyvisa/attributes.py
@@ -757,11 +757,22 @@ class AttrVI_ATTR_ASRL_XON_CHAR(RangeAttribute):
     min_value, max_value, values = 0, 0xFF, []
 
 
-# Could not generate class for VI_ATTR_BUFFER.html
-# Exception:
-"""
-'list' object has no attribute 'startswith'
-"""
+# noinspection PyPep8Naming
+class AttrVI_ATTR_BUFFER(Attribute):
+    """VI_ATTR_BUFFER contains the address of a buffer that was used in an
+    asynchronous operation.
+    """
+    resources = [constants.EventType.io_completion]
+
+    py_name = 'buffer'
+
+    visa_name = 'VI_ATTR_BUFFER'
+
+    visa_type = 'ViBuf'
+
+    default = NotAvailable
+
+    read, write, local = True, False, True
 
 
 # noinspection PyPep8Naming
@@ -908,11 +919,37 @@ class AttrVI_ATTR_DMA_ALLOW_EN(BooleanAttribute):
     read, write, local = True, True, True
 
 
-# Could not generate class for VI_ATTR_EVENT_TYPE.html
-# Exception:
-"""
-Unknown type: ViEventType. Range: [u'0h to FFFFFFFFh']
-"""
+# noinspection PyPep8Naming
+class AttrVI_ATTR_EVENT_TYPE(RangeAttribute):
+    """VI_ATTR_EVENT_TYPE is the unique logical identifier for the event type
+    of the specified event.
+    """
+    resources = [(constants.InterfaceType.gpib, 'INSTR'),
+                 (constants.InterfaceType.gpib, 'INTFC'),
+                 (constants.InterfaceType.gpib, 'SERVANT'),
+                 (constants.InterfaceType.gpib_vxi, 'INSTR'),
+                 (constants.InterfaceType.gpib_vxi, 'MEMACC'),
+                 (constants.InterfaceType.gpib_vxi, 'BACKPLANE'),
+                 (constants.InterfaceType.pxi, 'INSTR'),
+                 (constants.InterfaceType.asrl, 'INSTR'),
+                 (constants.InterfaceType.tcpip, 'INSTR'),
+                 (constants.InterfaceType.tcpip, 'SOCKET'),
+                 (constants.InterfaceType.vxi, 'INSTR'),
+                 (constants.InterfaceType.vxi, 'MEMACC'),
+                 (constants.InterfaceType.vxi, 'BACKPLANE'),
+                 (constants.InterfaceType.vxi, 'SERVANT')]
+
+    py_name = 'event_type'
+
+    visa_name = 'VI_ATTR_EVENT_TYPE'
+
+    visa_type = 'ViEventType'
+
+    default = NotAvailable
+
+    read, write, local = True, False, True
+
+    min_value, max_value, values = 0, 0xFFFFFFFF, []
 
 
 # noinspection PyPep8Naming
@@ -1348,6 +1385,23 @@ class AttrVI_ATTR_IO_PROT(RangeAttribute):
 
 
 # noinspection PyPep8Naming
+class AttrVI_ATTR_JOB_ID(Attribute):
+    """VI_ATTR_JOB_ID contains the job ID of the asynchronous operation that has completed.
+    """
+    resources= [constants.EventType.io_completion]
+
+    py_name = 'job_id'
+
+    visa_name = 'VI_ATTR_JOB_ID'
+
+    visa_type = 'ViJobId'
+
+    default = NotAvailable
+
+    read, write, local = True, False, True
+
+
+# noinspection PyPep8Naming
 class AttrVI_ATTR_MAINFRAME_LA(RangeAttribute):
     """VI_ATTR_MA.infRAME_LA specifies the lowest logical address in the
     mainframe. If the logical address is not known, VI_UNKNOWN_LA is
@@ -1523,6 +1577,25 @@ class AttrVI_ATTR_MODEL_NAME(Attribute):
     read, write, local = True, False, False
 
     # [u'N/A']
+
+
+# noinspection PyPep8Naming
+class AttrVI_ATTR_OPER_NAME(Attribute):
+    """VI_ATTR_OPER_NAME contains the name of the operation generating this
+    event.
+    """
+    resources = [constants.EventType.io_completion,
+                 constants.EventType.exception]
+
+    py_name = 'oper_name'
+
+    visa_name = 'VI_ATTR_OPER_NAME'
+
+    visa_type = 'ViString'
+
+    default = NotAvailable
+
+    read, write, local = True, False, True
 
 
 # noinspection PyPep8Naming
@@ -2334,6 +2407,25 @@ class AttrVI_ATTR_SRC_INCREMENT(RangeAttribute):
 
 
 # noinspection PyPep8Naming
+class AttrVI_ATTR_STATUS(Attribute):
+    """VI_ATTR_STATUS contains the return code of the operation generating this
+    event.
+    """
+    resources = [constants.EventType.exception,
+                 constants.EventType.io_completion]
+
+    py_name = 'status'
+
+    visa_name = 'VI_ATTR_STATUS'
+
+    visa_type = 'ViStatus'
+
+    default = NotAvailable
+
+    read, write, local = True, False, True
+
+
+# noinspection PyPep8Naming
 class AttrVI_ATTR_SUPPRESS_END_EN(BooleanAttribute):
     """VI_ATTR_SUPPRESS_END_EN is relevant only in viRead and related
     operations.
@@ -2586,6 +2678,26 @@ class AttrVI_ATTR_TRIG_ID(ValuesAttribute):
     read, write, local = True, True, True
 
     values = [] #TODO
+
+
+# noinspection PyPep8Naming
+class AttrVI_ATTR_RET_COUNT(RangeAttribute):
+    """VI_ATTR_RET_COUNT contains the actual number of elements that were
+    asynchronously transferred.
+    """
+    resources = [constants.EventType.io_completion]
+
+    py_name = 'ret_count'
+
+    visa_name = 'VI_ATTR_RET_COUNT'
+
+    visa_type = 'ViUInt32'
+
+    default = NotAvailable
+
+    read, write, local = True, False, True
+
+    min_value, max_value, values = 0, 0xFFFFFFFF, []
 
 
 # noinspection PyPep8Naming

--- a/pyvisa/compat/__init__.py
+++ b/pyvisa/compat/__init__.py
@@ -132,6 +132,12 @@ try:
 except ImportError:
     from .nullhandler import NullHandler
 
+try:
+    from types import coroutine
+except ImportError:
+    def coroutine(gen_func):
+        return gen_func
+
 
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -17,11 +17,13 @@ from __future__ import (division, unicode_literals, print_function,
 import contextlib
 import time
 import warnings
+from collections import OrderedDict
 
 from .. import logger
 from .. import constants
 from .. import errors
 from .. import util
+from ..compat import coroutine
 
 from .resource import Resource
 
@@ -98,6 +100,8 @@ class MessageBasedResource(Resource):
     def __init__(self, *args, **kwargs):
         self._values_format = ValuesFormat()
         super(MessageBasedResource, self).__init__(*args, **kwargs)
+        self._io_events_enabled = False
+        self._jobs = OrderedDict()
 
     # This is done for backwards compatibility but will be removed in 1.10
     @property
@@ -391,6 +395,132 @@ class MessageBasedResource(Resource):
                 raise
 
         return ret
+
+    def start_async_read(self, size=None):
+        """Start an asynchronous read operation and return immediately.
+
+        :param size: The chunk size to use when reading the data.
+        """
+
+        if not self._io_events_enabled:
+            self.visalib.enable_event(self.session,
+                                      constants.VI_EVENT_IO_COMPLETION,
+                                      constants.VI_QUEUE)
+            self._io_events_enabled = True
+        size = self.chunk_size if size is None else size
+        buf, job_id, status = self.visalib.read_asynchronously(self.session, size)
+        self._jobs[job_id.value] = buf
+
+    def check_async_read(self, timeout=0):
+        """Check if an async read is finished and return the message if so.
+
+        Returns None if the read operation has not yet finished. Note that this
+        method can raise a VisaIOError if the read operation itself times out. A
+        timeout of 0 can be used to poll the operation and return immediately.
+
+        :param timeout: How long (in milliseconds) to wait for the IO completion
+            event
+
+        """
+        msg, _ = self._check_async_read(timeout)
+        return msg
+
+    def _check_async_read(self, timeout=0):
+        try:
+            ev_type, ctx, status = self.visalib.wait_on_event(
+                self.session, constants.VI_EVENT_IO_COMPLETION, timeout)
+        except errors.VisaIOError as e:
+            if e.error_code == constants.VI_ERROR_TMO:
+                return None, None
+            raise
+
+        job_status, _ = self.visalib.get_attribute(ctx, constants.VI_ATTR_STATUS)
+        if job_status < 0:
+            raise errors.VisaIOError(job_status)
+
+        job_id, _ = self.visalib.get_attribute(ctx, constants.VI_ATTR_JOB_ID)
+        count, _ = self.visalib.get_attribute(ctx, constants.VI_ATTR_RET_COUNT)
+        self.visalib.close(ctx)
+
+        buf = self._jobs.pop(job_id)
+        return buf[:count], job_status
+
+    @coroutine
+    def _async_read_chunk(self, size=None):
+        with self.ignore_warning(constants.VI_SUCCESS_SYNC):
+            self.start_async_read(size)
+
+        while True:
+            yield
+            msg, job_status = self._check_async_read(timeout=0)
+            if msg is not None:
+                return msg, job_status
+
+    @coroutine
+    def _async_read_raw(self, size=None):
+        ret = bytearray()
+        job_status = loop_status = constants.StatusCode.success_max_count_read
+        with self.ignore_warning(constants.VI_SUCCESS_DEV_NPRESENT,
+                                 constants.VI_SUCCESS_MAX_CNT):
+            while job_status == loop_status:
+                logger.debug('%s - reading %d bytes (last status %r)',
+                             self._resource_name, size, job_status)
+                msg, job_status = yield from self._async_read_chunk(size)
+                ret.extend(msg)
+        return bytes(ret)
+
+    @coroutine
+    def async_read_raw(self, size=None):
+        """Read the unmodified string asynchronously
+
+        In contrast to async_read(), no termination characters are stripped.
+
+        Use ``yield from`` to get the value from within another coroutine or
+        generator::
+            msg = yield from resource.async_read_raw()
+
+        :param size: The chunk size to use when reading the data.
+
+        :rtype: bytes
+        """
+        return bytes((yield from self._async_read_raw(size)))
+
+    @coroutine
+    def async_read(self, termination=None, encoding=None):
+        """Read a string from the device asynchronously.
+
+        Use ``yield from`` to get the value from within another coroutine or
+        generator::
+            msg = yield from resource.async_read()
+
+        Reading stops when the device stops sending (e.g. by setting
+        appropriate bus lines), or the termination characters sequence was
+        detected.  Attention: Only the last character of the termination
+        characters is really used to stop reading, however, the whole sequence
+        is compared to the ending of the read string message.  If they don't
+        match, a warning is issued.
+
+        All line-ending characters are stripped from the end of the string.
+
+        :rtype: str
+        """
+        enco = self._encoding if encoding is None else encoding
+
+        if termination is None:
+            termination = self._read_termination
+            message = (yield from self._async_read_raw()).decode(enco)
+        else:
+            with self.read_termination_context(termination):
+                message = (yield from self._async_read_raw()).decode(enco)
+
+        if not termination:
+            return message
+
+        if not message.endswith(termination):
+            warnings.warn("read string doesn't end with "
+                          "termination characters", stacklevel=2)
+
+        return message[:-len(termination)]
 
     def read(self, termination=None, encoding=None):
         """Read a string from the device.


### PR DESCRIPTION
This PR added attributes related to IO_COMPLETION events, along with some methods for performing generator-based asynchronous reads.

I've tested this by pulling data from two oscilloscopes simultaneously, and it has worked well.