### PR TITLE
ResourceManager.list_opened_resources

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,10 @@ PyVISA Changelog
 1.10 (unreleased)
 -----------------
 
+- add a list_opened_resources method to the ResourceManager PR #415
+- use privately stored resource name in Resource class rather than relying on
+  VisaLibrary PR #415
+- keep track of resources created by the ResourceManager to properly close them PR #357
 - make the ordering of the visa library deterministic PR #399
 - properly close pipes when looking for a shared libary path on linux #380
 - fixing missing argument for USBInstrument.usb_control_out PR #353

--- a/docs/source/introduction/communication.rst
+++ b/docs/source/introduction/communication.rst
@@ -79,6 +79,13 @@ is the same as::
     >>> print(my_instrument.read())
 
 
+.. note::
+
+    You can access all the opened resources by calling
+    ``rm.list_opened_resources()``. This will return a list of ``Resource``,
+    however note that this list is not dynamically updated.
+
+
 Getting the instrument configuration right
 ------------------------------------------
 

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -1659,6 +1659,14 @@ class ResourceManager(object):
         return dict((resource, self.resource_info(resource))
                     for resource in self.list_resources(query))
 
+    def list_opened_resources(self):
+        """Returns a list of all the opened resources.
+
+        :return: List of resources
+        :rtype: list[:class:`pyvisa.resources.resource.Resource`]
+        """
+        return list(self._created_resources)
+
     def resource_info(self, resource_name, extended=True):
         """Get the (extended) information of a particular resource.
 

--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -80,6 +80,11 @@ class Resource(object):
     def __init__(self, resource_manager, resource_name):
         self._resource_manager = resource_manager
         self.visalib = self._resource_manager.visalib
+
+        # We store the resource name and use preferably the private attr over
+        # the public descriptor intyernally because the public descriptor
+        # requires a live instance the VISA library, which means it is much
+        # slower but also can cause issue in error reporting in th repr.
         self._resource_name = resource_name
 
         self._logging_extra = {'library_path': self.visalib.library_path,
@@ -103,13 +108,6 @@ class Resource(object):
     @session.setter
     def session(self, value):
         self._session = value
-
-    @property
-    def resource_name(self):
-        """Resource name used to open this resource.
-
-        """
-        return self._resource_name
 
     def __del__(self):
         self.close()

--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -104,14 +104,21 @@ class Resource(object):
     def session(self, value):
         self._session = value
 
+    @property
+    def resource_name(self):
+        """Resource name used to open this resource.
+
+        """
+        return self._resource_name
+
     def __del__(self):
         self.close()
 
     def __str__(self):
-        return "%s at %s" % (self.__class__.__name__, self.resource_name)
+        return "%s at %s" % (self.__class__.__name__, self._resource_name)
 
     def __repr__(self):
-        return "<%r(%r)>" % (self.__class__.__name__, self.resource_name)
+        return "<%r(%r)>" % (self.__class__.__name__, self._resource_name)
 
     def __enter__(self):
         return self
@@ -180,14 +187,14 @@ class Resource(object):
 
         :rtype: :class:`pyvisa.highlevel.ResourceInfo`
         """
-        return self.visalib.parse_resource_extended(self._resource_manager.session, self.resource_name)
+        return self.visalib.parse_resource_extended(self._resource_manager.session, self._resource_name)
 
     @property
     def interface_type(self):
         """The interface type of the resource as a number.
         """
         return self.visalib.parse_resource(self._resource_manager.session,
-                                           self.resource_name)[0].interface_type
+                                           self._resource_name)[0].interface_type
 
     def ignore_warning(self, *warnings_constants):
         """Ignoring warnings context manager for the current resource.


### PR DESCRIPTION
Based on @ruggiamp suggestion in #414, add a `list_opened_resources` method to the resource manager returning a snapshot of the opened resources. The documentation has been updated to add an example of its usage.

Also in the Resource class we use consistently the resource name stored in the private attribute (`_resource_name`) to avoid relying on the VisaLibrary object to get it. This should fix issues such as https://github.com/pyvisa/pyvisa-py/issues/151.

@ruggiamp please test if you can (I already tested locally).

@hgrecco @tivek please review if you can.