### PR TITLE
HISLIP - Fix partial reads in binary data which cause VI_ERROR_CONN_LOST

### DIFF
--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -495,7 +495,7 @@ class MessageBasedResource(Resource):
         if data_length is not None:
             block.extend(self.read_bytes(data_length))
         else:
-            block.extend(self.read_raw())
+            block.extend(self._read_raw())
 
         if expect_termination and self._read_termination is not None:
             expected_length += len(self._read_termination)

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -503,7 +503,7 @@ class MessageBasedResource(Resource):
 
             expected_length = offset + data_length
 
-        else header_fmt == 'empty':
+        elif header_fmt == 'empty':
 
             block = block + self._read_raw()
 

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -503,6 +503,10 @@ class MessageBasedResource(Resource):
 
             expected_length = offset + data_length
 
+        else header_fmt == 'empty':
+
+            block = block + self._read_raw()
+
         if expect_termination and self._read_termination is not None:
             expected_length += len(self._read_termination)
 


### PR DESCRIPTION
Fix partial reads in binary data which cause VI_ERROR_CONN_LOST when using HiSLIP protocol and large data sizes. Added case for when there is no header to read data as before.
