### PR TITLE
Remove use of time.clock under Python 3.3+

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ PyVISA Changelog
 1.10 (unreleased)
 -----------------
 
-- replace time.clock by time.perf_counter under Python 3
+- replace time.clock by time.perf_counter under Python 3 PR #441
 - make the ordering of the visa library deterministic PR #399
 - properly close pipes when looking for a shared libary path on linux #380
 - fixing missing argument for USBInstrument.usb_control_out PR #353

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA Changelog
 1.10 (unreleased)
 -----------------
 
+- replace time.clock by time.perf_counter under Python 3
 - make the ordering of the visa library deterministic PR #399
 - properly close pipes when looking for a shared libary path on linux #380
 - fixing missing argument for USBInstrument.usb_control_out PR #353

--- a/pyvisa/resources/gpib.py
+++ b/pyvisa/resources/gpib.py
@@ -14,6 +14,12 @@
 from __future__ import division, unicode_literals, print_function, absolute_import
 
 import time
+import sys
+
+if sys.version_info > (3,2):
+    perf_counter = time.perf_counter
+else:
+    perf_counter = time.clock
 
 from .. import constants
 from .resource import Resource
@@ -98,13 +104,15 @@ class GPIBInstrument(_GPIBMixin, MessageBasedResource):
         if timeout and not(0 <= timeout <= 4294967295):
             raise ValueError("timeout value is invalid")
 
-        starting_time = time.clock()
+        starting_time = perf_counter()
 
         while True:
             if timeout is None:
                 adjusted_timeout = constants.VI_TMO_INFINITE
             else:
-                adjusted_timeout = int((starting_time + timeout/1e3 - time.clock())*1e3)
+                adjusted_timeout = int((starting_time +
+                                        timeout/1e3 -
+                                        perf_counter())*1e3)
                 if adjusted_timeout < 0:
                     adjusted_timeout = 0
 


### PR DESCRIPTION
Instead we use perf_counter.

Closes #394