### PR TITLE
Change ni to ivi backend name "Reduce bias towards National Instruments (issue 455)"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ PyVISA Changelog
 1.11 (unreleased)
 -----------------
 
+- Make the library less biased towards National Instrument by referring to IVI
+  where relevant PR #456
 
 1.10.1 (unreleased)
 -------------------

--- a/docs/source/advanced/architecture.rst
+++ b/docs/source/advanced/architecture.rst
@@ -52,7 +52,7 @@ given resource, you will use the |open_resource| method to obtain the
 appropriate object. If needed, you will be able to access the ``VisaLibrary``
 object directly using the |visalib| attribute.
 
-The ``VisaLibrary`` does the low-level calls. In the default NI Backend,
+The ``VisaLibrary`` does the low-level calls. In the default IVI Backend,
 levels 1 and 2 are implemented in the same package called
 :mod:`pyvisa.ctwrapper` (which stands for ctypes wrapper). This package is
 included in PyVISA.

--- a/docs/source/advanced/backends.rst
+++ b/docs/source/advanced/backends.rst
@@ -17,7 +17,8 @@ Since 1.6, PyVISA is a frontend to VISA. It provides a nice, Pythonic API and
 can connect to multiple backends. Each backend exposes a class derived from
 VisaLibraryBase that implements the low-level communication. The ctypes wrapper
 around IVI-VISA is the default backend (called **ivi**) and is bundled with
-PyVISA for simplicity. In general, IVI-VISA can be NI-VISA, R&SVISA, tekVISA etc.
+PyVISA for simplicity. In general, IVI-VISA can be NI-VISA, Keysight VISA,
+R&S VISA, tekVISA etc.
 By default, it calls the library that is installed on your system as VISA library.
 
 You can specify the backend to use when you instantiate the resource manager

--- a/docs/source/advanced/backends.rst
+++ b/docs/source/advanced/backends.rst
@@ -16,11 +16,12 @@ Users had to change their programs to use other packages with different API.
 Since 1.6, PyVISA is a frontend to VISA. It provides a nice, Pythonic API and
 can connect to multiple backends. Each backend exposes a class derived from
 VisaLibraryBase that implements the low-level communication. The ctypes wrapper
-around NI-VISA is the default backend (called **ni**) and is bundled with
-PyVISA for simplicity.
+around IVI-VISA is the default backend (called **ivi**) and is bundled with
+PyVISA for simplicity. In general, IVI-VISA can be NI-VISA, R&SVISA, tekVISA etc.
+By default, it calls the library that is installed on your system as VISA library.
 
 You can specify the backend to use when you instantiate the resource manager
-using the ``@`` symbol. Remembering that **ni** is the default, this::
+using the ``@`` symbol. Remembering that **ivi** is the default, this::
 
     >>> import visa
     >>> rm = visa.ResourceManager()
@@ -28,12 +29,12 @@ using the ``@`` symbol. Remembering that **ni** is the default, this::
 is the same as this::
 
     >>> import visa
-    >>> rm = visa.ResourceManager('@ni')
+    >>> rm = visa.ResourceManager('@ivi')
 
 You can still provide the path to the library if needed::
 
     >>> import visa
-    >>> rm = visa.ResourceManager('/path/to/lib@ni')
+    >>> rm = visa.ResourceManager('/path/to/lib@ivi')
 
 Under the hood, the |ResourceManager| looks for the requested backend and
 instantiate the VISA library that it provides.

--- a/docs/source/introduction/communication.rst
+++ b/docs/source/introduction/communication.rst
@@ -25,7 +25,7 @@ This example already shows the two main design goals of PyVISA: preferring
 simplicity over generality, and doing it the object-oriented way.
 
 After importing ``visa``, we create a ``ResourceManager`` object. If called
-without arguments, PyVISA will prefer the default backend (NI) which tries to
+without arguments, PyVISA will prefer the default backend (IVI) which tries to
 find the VISA shared library for you. If it fails it will fall back to
 pyvisa-py if installed. You can check what backend is used and the location of
 the shared library used, if relevant, simply by:

--- a/docs/source/introduction/configuring.rst
+++ b/docs/source/introduction/configuring.rst
@@ -6,7 +6,7 @@ Configuring the backend
 .. include:: ../substitutions.sub
 
 Currently there are two backends available: The one included in pyvisa, which
-uses the IVI library (include NI-VISA, R&SVISA, tekVISA etc.),
+uses the IVI library (include NI-VISA, Keysight VISA, R&S VISA, tekVISA etc.),
 and the backend provided by pyvisa-py, which is a pure python implementation
 of the VISA library. If no backend is specified, pyvisa uses the IVI backend
 if any IVI library has been installed (see next section for details).

--- a/docs/source/introduction/configuring.rst
+++ b/docs/source/introduction/configuring.rst
@@ -6,10 +6,11 @@ Configuring the backend
 .. include:: ../substitutions.sub
 
 Currently there are two backends available: The one included in pyvisa, which
-uses the NI library, and the backend provided by pyvisa-py, which is a pure
-python implementation of the VISA library. If no backend is specified, pyvisa
-uses the NI backend if the NI library has been installed (see next section for
-details). Failing that, it uses the pyvisa-py backend.
+uses the IVI library (include NI-VISA, R&SVISA, tekVISA etc.),
+and the backend provided by pyvisa-py, which is a pure python implementation
+of the VISA library. If no backend is specified, pyvisa uses the IVI backend
+if any IVI library has been installed (see next section for details).
+Failing that, it uses the pyvisa-py backend.
 
 You can also select a desired backend by passing a parameter to the
 ResourceManager, shown here for pyvisa-py:
@@ -19,13 +20,14 @@ ResourceManager, shown here for pyvisa-py:
 Alternatively it can also be selected by setting the environment variable
 PYVISA_LIBRARY. It takes the same values as the ResourceManager constructor.
 
-Configuring the NI backend
+Configuring the IVI backend
 --------------------------
 
 .. note::
 
-    The NI backend requires that you install first the NI-VISA library. You can
-    get info here: (:ref:`faq-getting-nivisa`)
+    The IVI backend requires that you install first the IVI-VISA library.
+    For example you can use NI-VISA or any other library in your opinion.
+    about NI-VISA get info here: (:ref:`faq-getting-nivisa`)
 
 
 In most cases PyVISA will be able to find the location of the shared visa

--- a/docs/source/introduction/shell.rst
+++ b/docs/source/introduction/shell.rst
@@ -174,7 +174,7 @@ or::
 
     pyvisa-shell -b py
 
-uses python-py as backend instead of ni backend, for situation when ni not
+uses python-py as backend instead of ivi backend, for situation when ivi not
 installed.
 
 

--- a/pyvisa/__init__.py
+++ b/pyvisa/__init__.py
@@ -3,12 +3,11 @@
     pyvisa
     ~~~~~~
 
-    Python wrapper of National Instrument (NI) Virtual Instruments Software
-    Architecture library (VISA).
+    Python wrapper of IVI Virtual Instruments Software Architecture library (VISA).
 
     This file is part of PyVISA.
 
-    :copyright: 2014 by PyVISA Authors, see AUTHORS for more details.
+    :copyright: 2014-2019 by PyVISA Authors, see AUTHORS for more details.
     :license: MIT, see LICENSE for more details.
 """
 

--- a/pyvisa/ctwrapper/__init__.py
+++ b/pyvisa/ctwrapper/__init__.py
@@ -3,11 +3,11 @@
     pyvisa.ctwrapper
     ~~~~~~~~~~~~~~~~
 
-    ctypes wrapper for NI-VISA library.
+    ctypes wrapper for IVI-VISA library.
 
     This file is part of PyVISA.
 
-    :copyright: 2014 by PyVISA Authors, see AUTHORS for more details.
+    :copyright: 2014-2019 by PyVISA Authors, see AUTHORS for more details.
     :license: MIT, see LICENSE for more details.
 """
 

--- a/pyvisa/ctwrapper/__init__.py
+++ b/pyvisa/ctwrapper/__init__.py
@@ -13,7 +13,7 @@
 
 from __future__ import division, unicode_literals, print_function, absolute_import
 
-from .highlevel import NIVisaLibrary
+from .highlevel import IVIVisaLibrary
 
-WRAPPER_CLASS = NIVisaLibrary
+WRAPPER_CLASS = IVIVisaLibrary
 

--- a/pyvisa/ctwrapper/highlevel.py
+++ b/pyvisa/ctwrapper/highlevel.py
@@ -51,7 +51,7 @@ def unique(seq):
 
 
 @add_visa_methods
-class NIVisaLibrary(highlevel.VisaLibraryBase):
+class IVIVisaLibrary(highlevel.VisaLibraryBase):
     """High level NI-VISA Library wrapper using ctypes.
 
     The easiest way to instantiate the library is to let `pyvisa` find the
@@ -59,11 +59,11 @@ class NIVisaLibrary(highlevel.VisaLibraryBase):
     If it fails, it uses `ctypes.util.find_library` to try to locate a library
     in a way similar to what the compiler does:
 
-       >>> visa_library = NIVisaLibrary()
+       >>> visa_library = IVIVisaLibrary()
 
     But you can also specify the path:
 
-        >>> visa_library = NIVisaLibrary('/my/path/visa.so')
+        >>> visa_library = IVIVisaLibrary('/my/path/visa.so')
 
     :param library_path: path of the VISA library.
     """
@@ -103,14 +103,14 @@ class NIVisaLibrary(highlevel.VisaLibraryBase):
         d = OrderedDict()
         d['Version'] = '%s (bundled with PyVISA)' % __version__
 
-        paths = NIVisaLibrary.get_library_paths()
+        paths = IVIVisaLibrary.get_library_paths()
 
         for ndx, visalib in enumerate(paths, 1):
             nfo = OrderedDict()
             nfo['found by'] = visalib.found_by
             nfo['bitness'] = visalib.bitness
             try:
-                lib = NIVisaLibrary(visalib)
+                lib = IVIVisaLibrary(visalib)
                 sess, _ = lib.open_default_resource_manager()
                 nfo['Vendor'] = str(lib.get_attribute(sess, constants.VI_ATTR_RSRC_MANF_NAME)[0])
                 nfo['Impl. Version'] = str(lib.get_attribute(sess, constants.VI_ATTR_RSRC_IMPL_VERSION)[0])

--- a/pyvisa/ctwrapper/highlevel.py
+++ b/pyvisa/ctwrapper/highlevel.py
@@ -23,7 +23,7 @@ from .cthelper import Library, find_library
 from . import functions
 
 
-logger = logging.LoggerAdapter(logger, {'backend': 'ni'})
+logger = logging.LoggerAdapter(logger, {'backend': 'ivi'})
 
 
 def add_visa_methods(aclass):
@@ -52,7 +52,7 @@ def unique(seq):
 
 @add_visa_methods
 class IVIVisaLibrary(highlevel.VisaLibraryBase):
-    """High level NI-VISA Library wrapper using ctypes.
+    """High level IVI-VISA Library wrapper using ctypes.
 
     The easiest way to instantiate the library is to let `pyvisa` find the
     right one for you. This looks first in your configuration file (~/.pyvisarc).
@@ -77,7 +77,7 @@ class IVIVisaLibrary(highlevel.VisaLibraryBase):
 
         from ..util import LibraryPath, read_user_library_path
 
-        # Try to find NI libraries using known names.
+        # Try to find IVI libraries using known names.
         tmp = [find_library(library_path)
                for library_path in ('visa', 'visa32', 'visa32.dll', 'visa64', 'visa64.dll')]
 
@@ -98,6 +98,7 @@ class IVIVisaLibrary(highlevel.VisaLibraryBase):
     @staticmethod
     def get_debug_info():
         """Return a list of lines with backend info.
+
         """
         from pyvisa import __version__
         d = OrderedDict()
@@ -259,3 +260,33 @@ class IVIVisaLibrary(highlevel.VisaLibraryBase):
 
         return tuple(resource for resource in resources)
 
+
+class NIVisaLibrary(IVIVisaLibrary):
+    """Deprecated name for IVIVisaLibrary.
+
+    This class will be removed in 1.12
+
+    """
+    @staticmethod
+    def get_library_paths():
+        """Return a tuple of possible library paths.
+
+        :rtype: tuple
+        """
+        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12."
+                      "Use IVIVisaLibrary instead.", FutureWarning)
+        IVIVisaLibrary.get_library_paths()
+
+    @staticmethod
+    def get_debug_info():
+        """Return a list of lines with backend info.
+
+        """
+        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12."
+                      "Use IVIVisaLibrary instead.", FutureWarning)
+        IVIVisaLibrary.get_debug_info()
+
+    def __new__(cls, library_path=''):
+        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12."
+                      "Use IVIVisaLibrary instead.", FutureWarning)
+        IVIVisaLibrary.__new__(cls, library_path)

--- a/pyvisa/ctwrapper/highlevel.py
+++ b/pyvisa/ctwrapper/highlevel.py
@@ -273,7 +273,7 @@ class NIVisaLibrary(IVIVisaLibrary):
 
         :rtype: tuple
         """
-        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12."
+        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12. "
                       "Use IVIVisaLibrary instead.", FutureWarning)
         IVIVisaLibrary.get_library_paths()
 
@@ -282,11 +282,11 @@ class NIVisaLibrary(IVIVisaLibrary):
         """Return a list of lines with backend info.
 
         """
-        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12."
+        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12. "
                       "Use IVIVisaLibrary instead.", FutureWarning)
         IVIVisaLibrary.get_debug_info()
 
     def __new__(cls, library_path=''):
-        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12."
+        warnings.warn("NIVisaLibrary is deprecated and will be removed in 1.12. "
                       "Use IVIVisaLibrary instead.", FutureWarning)
         IVIVisaLibrary.__new__(cls, library_path)

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -49,7 +49,7 @@ class VisaLibraryBase(object):
 
     The default VisaLibrary class is :class:`pyvisa.ctwrapper.highlevel.NIVisaLibrary`,
     which implements a ctypes wrapper around the IVI-VISA library.
-    Certainly, IVI-VISA can be NI-VISA, R&SVISA, tekVISA etc.
+    Certainly, IVI-VISA can be NI-VISA, Keysight VISA, R&S VISA, tekVISA etc.
 
     In general, you should not instantiate it directly. The object exposed to the user
     is the :class:`pyvisa.highlevel.ResourceManager`. If needed, you can access the

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -17,6 +17,7 @@ import contextlib
 import collections
 import pkgutil
 import os
+import warnings
 from collections import defaultdict
 from weakref import WeakSet
 
@@ -1442,7 +1443,7 @@ def list_backends():
     :rtype: list
     """
     return ['ivi'] + [name for (loader, name, ispkg) in pkgutil.iter_modules()
-                     if name.startswith('pyvisa-') and not name.endswith('-script')]
+                      if name.startswith('pyvisa-') and not name.endswith('-script')]
 
 #: Maps backend name to VisaLibraryBase derived class
 #: dict[str, :class:`pyvisa.highlevel.VisaLibraryBase`]
@@ -1459,13 +1460,14 @@ def get_wrapper_class(backend_name):
     try:
         return _WRAPPERS[backend_name]
     except KeyError:
-        if backend_name == 'ivi':
+        if backend_name == 'ivi' or backend_name == 'ni':
             from .ctwrapper import NIVisaLibrary
             _WRAPPERS['ivi'] = NIVisaLibrary
-            return NIVisaLibrary
-        elif backend_name == 'ni':
-            from .ctwrapper import NIVisaLibrary
-            _WRAPPERS['ivi'] = NIVisaLibrary
+            if backend_name == 'ni':
+                warnings.warn(
+                    '@ni backend name is no longer used by default and was'
+                    'replaced by @ivi Check the documentation for details',
+                    FutureWarning)
             return NIVisaLibrary
 
     try:

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -48,7 +48,8 @@ class VisaLibraryBase(object):
     derived class must/will implement all methods.
 
     The default VisaLibrary class is :class:`pyvisa.ctwrapper.highlevel.NIVisaLibrary`,
-    which implements a ctypes wrapper around the NI-VISA library.
+    which implements a ctypes wrapper around the IVI-VISA library.
+    Certainly, IVI-VISA can be NI-VISA, R&SVISA, tekVISA etc.
 
     In general, you should not instantiate it directly. The object exposed to the user
     is the :class:`pyvisa.highlevel.ResourceManager`. If needed, you can access the

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -1479,8 +1479,8 @@ def get_wrapper_class(backend_name):
 def _get_default_wrapper():
     """Return an available default VISA wrapper as a string ('ivi' or 'py').
 
-    Use NI if the binary is found, else try to use pyvisa-py.
-    'ni' VISA wrapper is NOT used since version > 10.0.0
+    Use IVI if the binary is found, else try to use pyvisa-py.
+    'ni' VISA wrapper is NOT used since version > 1.10.0
     If neither can be found, raise a ValueError.
     """
 

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -1454,6 +1454,7 @@ def get_wrapper_class(backend_name):
     """Return the WRAPPER_CLASS for a given backend.
 
     backend_name == 'ni' is used for backwards compatibility
+    and will be removed in 1.12.
 
     :rtype: pyvisa.highlevel.VisaLibraryBase
     """
@@ -1465,8 +1466,9 @@ def get_wrapper_class(backend_name):
             _WRAPPERS['ivi'] = IVIVisaLibrary
             if backend_name == 'ni':
                 warnings.warn(
-                    '@ni backend name is no longer used by default and was'
-                    'replaced by @ivi Check the documentation for details',
+                    '@ni backend name is deprecated and will be '
+                    'removed in 1.12. Use @ivi instead. '
+                    'Check the documentation for details',
                     FutureWarning)
             return IVIVisaLibrary
 
@@ -1482,7 +1484,10 @@ def _get_default_wrapper():
     """Return an available default VISA wrapper as a string ('ivi' or 'py').
 
     Use IVI if the binary is found, else try to use pyvisa-py.
+
     'ni' VISA wrapper is NOT used since version > 1.10.0
+    and will be removed in 1.12
+
     If neither can be found, raise a ValueError.
     """
 

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -48,7 +48,7 @@ class VisaLibraryBase(object):
     to the underlying devices providing Pythonic wrappers to VISA functions. But not all
     derived class must/will implement all methods.
 
-    The default VisaLibrary class is :class:`pyvisa.ctwrapper.highlevel.NIVisaLibrary`,
+    The default VisaLibrary class is :class:`pyvisa.ctwrapper.highlevel.IVIVisaLibrary`,
     which implements a ctypes wrapper around the IVI-VISA library.
     Certainly, IVI-VISA can be NI-VISA, Keysight VISA, R&S VISA, tekVISA etc.
 
@@ -1461,14 +1461,14 @@ def get_wrapper_class(backend_name):
         return _WRAPPERS[backend_name]
     except KeyError:
         if backend_name == 'ivi' or backend_name == 'ni':
-            from .ctwrapper import NIVisaLibrary
-            _WRAPPERS['ivi'] = NIVisaLibrary
+            from .ctwrapper import IVIVisaLibrary
+            _WRAPPERS['ivi'] = IVIVisaLibrary
             if backend_name == 'ni':
                 warnings.warn(
                     '@ni backend name is no longer used by default and was'
                     'replaced by @ivi Check the documentation for details',
                     FutureWarning)
-            return NIVisaLibrary
+            return IVIVisaLibrary
 
     try:
         pkg = __import__('pyvisa-' + backend_name)
@@ -1486,8 +1486,8 @@ def _get_default_wrapper():
     If neither can be found, raise a ValueError.
     """
 
-    from .ctwrapper import NIVisaLibrary
-    ni_binary_found = bool(NIVisaLibrary.get_library_paths())
+    from .ctwrapper import IVIVisaLibrary
+    ni_binary_found = bool(IVIVisaLibrary.get_library_paths())
     if ni_binary_found:
         logger.debug('The IVI implementation available')
         return 'ivi'

--- a/visa.py
+++ b/visa.py
@@ -26,7 +26,7 @@ def visa_main(command=None):
     parser = argparse.ArgumentParser(description='PyVISA command-line utilities')
 
     parser.add_argument('--backend', '-b', dest='backend', action='store', default=None,
-                        help='backend to be used (default: ni)')
+                        help='backend to be used (default: ivi)')
 
     if not command:
         subparsers = parser.add_subparsers(title='command', dest='command')


### PR DESCRIPTION
I made change in:

- 'highlevel.py' more precisely in list_backends(),  get_wrapper_class() and _get_default_wrapper() functions. 
- 'visa.py'
- Docs files

To my mind it's enough. 
Of course, I tested it as much as I could.
![testing](https://user-images.githubusercontent.com/42816781/63608113-d47dc500-c5dc-11e9-983d-d11670a7716e.PNG)
![fixed](https://user-images.githubusercontent.com/42816781/63608173-fc6d2880-c5dc-11e9-8c17-7e29011abc1f.PNG)

I'm not sure about docs, please double check it.

