### PR TITLE
Add the ability to specify 'dependency paths' which are used during .…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ PyVISA Changelog
 1.11 (unreleased)
 -----------------
 
+- Add support for dll_extra_paths in .pyvisarc to provide a way to specify paths
+  in which to look for dll on Windows and Python >= 3.8  PR #509
 - Drop Python 2 support PR #486
 - Limit support to Python 3.6+ PR #486
 - Improve the test suite and introduce tests relying on Keysight Virtual

--- a/docs/source/faq/faq.rst
+++ b/docs/source/faq/faq.rst
@@ -152,6 +152,16 @@ or
      You can also create a `virtual environment`_ for this.
 
 
+OSError: Could not open VISA library: function 'viOpen' not found
+-----------------------------------------------------------------
+
+Starting with Python 3.8, the .dll load behavior has changed on Windows (see
+`https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew`_). This causes
+some versions of Keysight VISA to fail to load because it cannot find its .dll
+dependencies. You can solve it by creating a configuration file and setting `dll_extra_paths`
+as described in :ref:`intro-configuring`.
+
+
 Where can I get more information about VISA?
 --------------------------------------------
 
@@ -186,3 +196,6 @@ Where can I get more information about VISA?
 .. _`AUTHORS`: https://github.com/pyvisa/pyvisa/blob/master/AUTHORS
 .. _`Issue Tracker`: https://github.com/pyvisa/pyvisa/issues
 .. _`virtual environment`: http://www.virtualenv.org/en/latest/
+
+.. _`https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew`:
+       https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew

--- a/docs/source/introduction/configuring.rst
+++ b/docs/source/introduction/configuring.rst
@@ -66,11 +66,11 @@ contain the following::
    [Paths]
 
    VISA library: /usr/lib/libvisa.so.7
-   dependency paths=/my/otherpath/;/my/otherpath2
+   dll_extra_paths=/my/otherpath/;/my/otherpath2
 
 Please note that `[Paths]` is treated case-sensitively.
 
-`dependency paths` can be used to specify folders to search for library dependencies
+`dll_extra_paths` can be used to specify folders to search for library dependencies
 
 You can define a site-wide configuration file at
 :file:`/usr/share/pyvisa/.pyvisarc` (It may also be

--- a/docs/source/introduction/configuring.rst
+++ b/docs/source/introduction/configuring.rst
@@ -66,11 +66,15 @@ contain the following::
    [Paths]
 
    VISA library: /usr/lib/libvisa.so.7
-   dll_extra_paths=/my/otherpath/;/my/otherpath2
 
 Please note that `[Paths]` is treated case-sensitively.
 
-`dll_extra_paths` can be used to specify folders to search for library dependencies
+To specify extra .dll search paths on Windows, use a `.pyvisarc` file like the following::
+
+   [Paths]
+
+   dll_extra_paths: C:\Program Files\Keysight\IO Libraries Suite\bin;C:\Program Files (x86)\Keysight\IO Libraries Suite\bin
+
 
 You can define a site-wide configuration file at
 :file:`/usr/share/pyvisa/.pyvisarc` (It may also be

--- a/docs/source/introduction/configuring.rst
+++ b/docs/source/introduction/configuring.rst
@@ -66,8 +66,11 @@ contain the following::
    [Paths]
 
    VISA library: /usr/lib/libvisa.so.7
+   dependency paths=/my/otherpath/;/my/otherpath2
 
 Please note that `[Paths]` is treated case-sensitively.
+
+`dependency paths` can be used to specify folders to search for library dependencies
 
 You can define a site-wide configuration file at
 :file:`/usr/share/pyvisa/.pyvisarc` (It may also be

--- a/pyvisa/ctwrapper/highlevel.py
+++ b/pyvisa/ctwrapper/highlevel.py
@@ -72,7 +72,10 @@ class IVIVisaLibrary(highlevel.VisaLibraryBase):
         :rtype: tuple
         """
 
-        from ..util import LibraryPath, read_user_library_path
+        from ..util import LibraryPath, read_user_library_path, add_user_dll_extra_paths
+
+        # Add extra .dll dependency search paths before attempting to load libraries
+        add_user_dll_extra_paths()
 
         # Try to find IVI libraries using known names.
         tmp = [find_library(library_path)

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -12,6 +12,7 @@ import unittest
 from configparser import ConfigParser
 from io import StringIO
 from functools import partial
+from unittest.mock import patch
 
 from pyvisa import util, highlevel
 from pyvisa.ctwrapper import IVIVisaLibrary
@@ -93,7 +94,9 @@ class TestConfigFile(BaseTestCase):
         config['Paths']["dll_extra_paths"] = "C:\Program Files;C:\Program Files (x86)"
         with open(self.config_path, "w") as f:
             config.write(f)
-        self.assertEqual(util.add_user_dll_extra_paths(), "C:\Program Files;C:\Program Files (x86)")
+        with patch('os.add_dll_directory') as mock:
+            mock.method.return_value = None
+            self.assertEqual(util.add_user_dll_extra_paths(), "C:\Program Files;C:\Program Files (x86)")
 
     def test_no_section_for_dll_extra_paths(self):
         sys.platform='win32'

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -77,6 +77,49 @@ class TestConfigFile(BaseTestCase):
             self.assertIsNone(util.read_user_library_path())
         self.assertIn("No user defined", cm.output[0])
 
+    """Test reading dll_extra_paths.
+
+    """
+    def test_reading_config_file_not_windows(self):
+        sys.platform='darwin'
+        with self.assertLogs(level='DEBUG') as cm:
+            self.assertIsNone(util.add_user_dll_extra_paths())
+        self.assertIn("Not loading dll_extra_paths because it is not Windows", cm.output[0])
+
+    def test_reading_config_file_for_dll_extra_paths(self):
+        sys.platform='win32'
+        config = ConfigParser()
+        config['Paths'] = {}
+        config['Paths']["dll_extra_paths"] = "C:\Program Files;C:\Program Files (x86)"
+        with open(self.config_path, "w") as f:
+            config.write(f)
+        self.assertEqual(util.add_user_dll_extra_paths(), "C:\Program Files;C:\Program Files (x86)")
+
+    def test_no_section_for_dll_extra_paths(self):
+        sys.platform='win32'
+        config = ConfigParser()
+        with open(self.config_path, "w") as f:
+            config.write(f)
+        with self.assertLogs(level='DEBUG') as cm:
+            self.assertIsNone(util.add_user_dll_extra_paths())
+        self.assertIn("NoOptionError or NoSectionError", cm.output[1])
+
+    def test_no_key_for_dll_extra_paths(self):
+        sys.platform='win32'
+        config = ConfigParser()
+        config['Paths'] = {}
+        with open(self.config_path, "w") as f:
+            config.write(f)
+        with self.assertLogs(level='DEBUG') as cm:
+            self.assertIsNone(util.add_user_dll_extra_paths())
+        self.assertIn("NoOptionError or NoSectionError", cm.output[1])
+
+    def test_no_config_file_for_dll_extra_paths(self):
+        sys.platform='win32'
+        with self.assertLogs(level='DEBUG') as cm:
+            self.assertIsNone(util.add_user_dll_extra_paths())
+        self.assertIn("No user defined", cm.output[0])
+
 class TestParser(BaseTestCase):
 
     def test_parse_binary(self):

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -64,6 +64,7 @@ def read_user_library_path():
 
         [Paths]
         visa library=/my/path/visa.so
+        dependency paths=/my/otherpath/;/my/otherpath2
 
     Return `None` if  configuration files or keys are not present.
 
@@ -82,6 +83,12 @@ def read_user_library_path():
 
     logger.debug('User defined library files: %s' % files)
     try:
+        try:
+            dependencyPaths = config_parser.get("Paths", "dependency paths")
+            for path in dependencyPaths.split(";"):
+                os.add_dll_directory(path)
+        except (NoOptionError, NoSectionError):
+            logger.debug('NoOptionError or NoSectionError while reading config file for dependency paths')
         return config_parser.get("Paths", "visa library")
     except (NoOptionError, NoSectionError):
         logger.debug('NoOptionError or NoSectionError while reading config file')

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -764,7 +764,6 @@ def get_arch(filename):
 
     out = subprocess.run(["file", filename], capture_output=True)
     out = out.stdout.decode("ascii")
-    print(out)
     ret = []
     if this_platform.startswith('linux'):
         if '32-bit' in out:

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -107,27 +107,31 @@ def add_user_dll_extra_paths():
     """
     from configparser import ConfigParser, NoSectionError, NoOptionError
 
-    config_parser = ConfigParser()
-    files = config_parser.read([os.path.join(sys.prefix, "share", "pyvisa",
-                                             ".pyvisarc"),
-                                os.path.join(os.path.expanduser("~"),
-                                             ".pyvisarc")])
-
-    if not files:
-        logger.debug('No user defined configuration')
-        return
-
-    logger.debug('User defined configuration files: %s' % files)
-
     this_platform = sys.platform
     if this_platform.startswith('win'):
+        config_parser = ConfigParser()
+        files = config_parser.read([os.path.join(sys.prefix, "share", "pyvisa",
+                                                ".pyvisarc"),
+                                    os.path.join(os.path.expanduser("~"),
+                                                ".pyvisarc")])
+
+        if not files:
+            logger.debug('No user defined configuration')
+            return None
+
+        logger.debug('User defined configuration files: %s' % files)
+
         try:
             dll_extra_paths = config_parser.get("Paths", "dll_extra_paths")
             for path in dll_extra_paths.split(";"):
                 os.add_dll_directory(path)
+            return dll_extra_paths
         except (NoOptionError, NoSectionError):
             logger.debug('NoOptionError or NoSectionError while reading config file for dll_extra_paths')
-
+            return None
+    else:
+        logger.debug('Not loading dll_extra_paths because it is not Windows')
+        return None
 
 class LibraryPath(str):
 

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -64,7 +64,7 @@ def read_user_library_path():
 
         [Paths]
         visa library=/my/path/visa.so
-        dependency paths=/my/otherpath/;/my/otherpath2
+        dll_extra_paths=/my/otherpath/;/my/otherpath2
 
     Return `None` if  configuration files or keys are not present.
 
@@ -84,11 +84,11 @@ def read_user_library_path():
     logger.debug('User defined library files: %s' % files)
     try:
         try:
-            dependencyPaths = config_parser.get("Paths", "dependency paths")
+            dependencyPaths = config_parser.get("Paths", "dll_extra_paths")
             for path in dependencyPaths.split(";"):
                 os.add_dll_directory(path)
         except (NoOptionError, NoSectionError):
-            logger.debug('NoOptionError or NoSectionError while reading config file for dependency paths')
+            logger.debug('NoOptionError or NoSectionError while reading config file for dll_extra_paths')
         return config_parser.get("Paths", "visa library")
     except (NoOptionError, NoSectionError):
         logger.debug('NoOptionError or NoSectionError while reading config file')


### PR DESCRIPTION
…dll dependency resolution.

I tested that this works with `visa library` defined, and when it is not. Also, if this section is not present the .pyvisarc file still loads.

The attached file will allow the latest version of Keysight VISA to work with Python 3.8, even without specifying the .dll (it allows it to find its dependency .dll's).

[.pyvisarc.zip](https://github.com/pyvisa/pyvisa/files/4584801/default.pyvisarc.zip)
