### PR TITLE
pyvisa.utils: add support for "s" and "p" format

### DIFF
--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -275,6 +275,19 @@ class TestParser(BaseTestCase):
                     fblock = lambda block, cont: fb(block, fmt, endi, cont)
                     self.round_trip_block_conversion(values, tblock, fblock, msg)
 
+    def test_bytes_binary_block(self):
+        values = b"dbslbw cj saj \x00\x76"
+        for block, tb, fb in zip(
+            ("ieee", "hp"),
+            (util.to_ieee_block, util.to_hp_block),
+            (util.from_ieee_block, util.from_hp_block),
+        ):
+            for fmt in "sp":
+                block = tb(values, datatype="s")
+                print(block)
+                rt = fb(block, datatype="s", container=bytes)
+                assert values == rt
+
     def test_malformed_binary_block_header(self):
         values = list(range(10))
         for header, tb, fb in zip(

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -692,9 +692,14 @@ def from_binary_block(
     fullfmt = "%s%d%s" % (endianess, array_length, datatype)
 
     try:
-        return container(struct.unpack_from(fullfmt, block, offset))
+        raw_data = struct.unpack_from(fullfmt, block, offset)
     except struct.error:
         raise ValueError("Binary data was malformed")
+
+    if datatype in "sp":
+        raw_data = raw_data[0]
+
+    return container(raw_data)
 
 
 def to_binary_block(
@@ -723,14 +728,19 @@ def to_binary_block(
 
     """
     array_length = len(iterable)
-
     endianess = ">" if is_big_endian else "<"
     fullfmt = "%s%d%s" % (endianess, array_length, datatype)
 
     if isinstance(header, str):
         header = bytes(header, "ascii")
 
-    return header + struct.pack(fullfmt, *iterable)
+    if datatype in ("s", "p"):
+        block = struct.pack(fullfmt, iterable)
+
+    else:
+        block = struct.pack(fullfmt, *iterable)
+
+    return header + block
 
 
 def to_ieee_block(


### PR DESCRIPTION
- [x] Closes #532 
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
