### PR TITLE
tests: add a test for clear on message based resources

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ steps:
     echo Install pytest and co
     pip install pytest pytest-azurepipelines pytest-cov
     echo Run pytest
-    python -X dev -m pytest --pyargs pyvisa --cov pyvisa --cov-report xml
+    python -X dev -m pytest --pyargs pyvisa --cov pyvisa --cov-report xml -v
   displayName: 'Run tests'
 
 - script: |

--- a/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
@@ -205,6 +205,18 @@ class MessagebasedResourceTestCase(ResourceTestCase):
         self.instr.write_raw(b"SEND\n")
         assert self.instr.read_raw(size=2) == b"test\n"
 
+    def test_clear(self):
+        """Test clearing the incoming buffer.
+
+        """
+        self.instr.write_raw(b"RECEIVE\n")
+        self.instr.write_raw(b"test\n")
+        self.instr.write_raw(b"SEND\n")
+        self.instr.clear()
+        self.instr.timeout = 10
+        with pytest.raises(errors.VisaIOError):
+            self.instr.read_raw()
+
     def test_write_read(self):
         """Test writing and reading.
 


### PR DESCRIPTION
- [x] Executed ``black . && isort -c . && flake8`` with no errors
