### PR TITLE
highlevel: avoid returning a generic resource info for a non-int board

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+  rev: v5.5.3
   hooks:
     - id: isort
 - repo: https://github.com/psf/black
-  rev: stable
+  rev: 20.8b1
   hooks:
     - id: black
       language_version: python3.7
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.3
   hooks:
     - id: flake8
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: ''  # Use the sha / tag you want to point at
+  rev: v0.782  # Use the sha / tag you want to point at
   hooks:
     - id: mypy
       additional_dependencies: [numpy, typing_extensions]

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ PyVISA Changelog
 
 - fix the listing of available backends (Also not that we now return the backend
   name as can be used to create a ResourceManger) PR #545
+- allow a None value for the board value of a ResourceInfo PR #547
+  This allows for funky resource name such ASRL/dev/tty0::INSTR which are common
+  in pyvisa-py and avoid returning a completely generic resource in those cases.
 
 1.11 (16-09-2020)
 -----------------

--- a/pyvisa/testsuite/test_highlevel.py
+++ b/pyvisa/testsuite/test_highlevel.py
@@ -60,7 +60,12 @@ class TestHighlevel(BaseTestCase):
         info, ret_code = lib.parse_resource_extended(None, rsc_name)
         # interface_type interface_board_number resource_class resource_name alias
         for parsed, value in zip(
-            info, values + (rname.to_canonical_name(rsc_name), None,),
+            info,
+            values
+            + (
+                rname.to_canonical_name(rsc_name),
+                None,
+            ),
         ):
             assert parsed == value
 

--- a/pyvisa/testsuite/test_highlevel.py
+++ b/pyvisa/testsuite/test_highlevel.py
@@ -19,29 +19,48 @@ class TestHighlevel(BaseTestCase):
 
     CHECK_NO_WARNING = False
 
-    def test_base_class_parse_resource(self):
+    @pytest.mark.parametrize(
+        "rsc_name, values",
+        [
+            ("TCPIP::192.168.0.1::INSTR", (constants.InterfaceType.tcpip, 0, "INSTR")),
+            ("TCPIP1::192.168.0.1::INSTR", (constants.InterfaceType.tcpip, 1, "INSTR")),
+            (
+                "TCPIP::192.168.0.1::5000::SOCKET",
+                (constants.InterfaceType.tcpip, 0, "SOCKET"),
+            ),
+            (
+                "TCPIP2::192.168.0.1::5000::SOCKET",
+                (constants.InterfaceType.tcpip, 2, "SOCKET"),
+            ),
+            ("GPIB::1::INSTR", (constants.InterfaceType.gpib, 0, "INSTR")),
+            ("GPIB::INTFC", (constants.InterfaceType.gpib, 0, "INTFC")),
+            ("GPIB2::1::INSTR", (constants.InterfaceType.gpib, 2, "INSTR")),
+            ("GPIB3::INTFC", (constants.InterfaceType.gpib, 3, "INTFC")),
+            (
+                "USB1::0x1111::0x2222::0x4445::0::RAW",
+                (constants.InterfaceType.usb, 1, "RAW"),
+            ),
+            (
+                "USB0::0x1112::0x2223::0x1234::0::INSTR",
+                (constants.InterfaceType.usb, 0, "INSTR"),
+            ),
+            ("ASRL2::INSTR", (constants.InterfaceType.asrl, 2, "INSTR")),
+            ("ASRL/dev/tty0::INSTR", (constants.InterfaceType.asrl, None, "INSTR")),
+        ],
+    )
+    def test_base_class_parse_resource(self, rsc_name, values):
         """Test the base class implementation of parse_resource."""
         lib = highlevel.VisaLibraryBase("test")
-        rsc_name = "TCPIP::192.168.0.1::INSTR"
         info, ret_code = lib.parse_resource(None, rsc_name)
 
         # interface_type interface_board_number resource_class resource_name alias
-        for parsed, value in zip(
-            info, (constants.InterfaceType.tcpip, 0, None, None, None)
-        ):
+        for parsed, value in zip(info, values[:2] + (None, None, None)):
             assert parsed == value
 
         info, ret_code = lib.parse_resource_extended(None, rsc_name)
         # interface_type interface_board_number resource_class resource_name alias
         for parsed, value in zip(
-            info,
-            (
-                constants.InterfaceType.tcpip,
-                0,
-                "INSTR",
-                rname.to_canonical_name(rsc_name),
-                None,
-            ),
+            info, values + (rname.to_canonical_name(rsc_name), None,),
         ):
             assert parsed == value
 


### PR DESCRIPTION
This typically happens for serial resource on Linux where we end up ASRL/dev/tty0::INSTR. Without this change users have to specify the resource class they want.

- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Added an entry to the CHANGES file
