### PR TITLE
Fix reading ieee empty block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test with pytest
         run: |
           pip install pytest-cov
-          pytest --pyargs pyvisa --cov pyvisa --cov-report xml -v
+          python -X dev -m pytest --pyargs pyvisa --cov pyvisa --cov-report xml -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ _test/
 htmlcov/
 .mypy_cache/
 pip-wheel-metadata/
+.pytest_cache

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,9 @@ PyVISA Changelog
   This changes should affect a minority of user and does not change the behavior for
   instrument returning #0 (only the value of data_length as returned by
   parse_ieee_block_header is affected and functions using it have been adapted).
+- allow trailing separators in ascii blocks PR #581
+  Numpy style extraction already handled this case correctly but it was not so
+  for the builtin parser.
 
 1.11.3 (07-11-2020)
 -------------------

--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,13 @@ PyVISA Changelog
 -------------------
 
 - fix collection of debug info on the ctypes wrapper PR #598
-
+- allow an IEEE binary block or an HP block to be empty PR #581
+  This is more correct and can affect real instruments. However this introduces
+  a minor backward incompatibility when parsing IEEE header. The data length for
+  #0 is now reported to be -1 instead of 0 since 0 corresponds to #10.
+  This changes should affect a minority of user and does not change the behavior for
+  instrument returning #0 (only the value of data_length as returned by
+  parse_ieee_block_header is affected and functions using it have been adapted).
 
 1.11.3 (07-11-2020)
 -------------------

--- a/docs/source/introduction/communication.rst
+++ b/docs/source/introduction/communication.rst
@@ -48,6 +48,7 @@ to filter the instruments discovered by this method. The syntax is described in
 details in |list_resources|. The default value is '?*::INSTR' which means that
 by default only instrument whose resource name ends with '::INSTR' are listed
 (in particular USB RAW resources and TCPIP SOCKET resources are not listed).
+To list all resources present, pass '?*' to ``list_resources``.
 
 In this case, there is a GPIB instrument with instrument number 14, so you ask
 the ``ResourceManager`` to open "'GPIB0::14::INSTR'" and assign the returned

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -2933,7 +2933,7 @@ def open_visa_library(specification: str = "") -> VisaLibraryBase:
 
 
 class ResourceManager(object):
-    """VISA Resource Manager. """
+    """VISA Resource Manager."""
 
     #: Maps (Interface Type, Resource Class) to Python class encapsulating that resource.
     _resource_classes: ClassVar[

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -537,7 +537,7 @@ class MessageBasedResource(Resource):
         container: Union[Type, Callable[[Iterable], Sequence]] = list,
         header_fmt: util.BINARY_HEADERS = "ieee",
         expect_termination: bool = True,
-        data_points: int = 0,
+        data_points: int = -1,
         chunk_size: Optional[int] = None,
     ) -> Sequence[Union[int, float]]:
         """Read values from the device in binary format returning an iterable

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -20,7 +20,7 @@ from .resource import Resource
 
 
 class ControlRenMixin(object):
-    """Common control_ren method of some messaged based resources. """
+    """Common control_ren method of some messaged based resources."""
 
     #: Will be present when used as a mixin with Resource
     visalib: VisaLibraryBase

--- a/pyvisa/resources/usb.py
+++ b/pyvisa/resources/usb.py
@@ -118,7 +118,7 @@ class USBInstrument(ControlRenMixin, USBCommon):
         index : int
             wIndex parameter of the setup stage of a USB control transfer.
             This is usually the index of the interface or endpoint.
-        data : str
+        data : bytes
             The data buffer that sends the data in the optional data stage of
             the control transfer.
 

--- a/pyvisa/shell.py
+++ b/pyvisa/shell.py
@@ -122,7 +122,7 @@ class VisaShell(cmd.Cmd):
             self.prompt = self.default_prompt
 
     def do_query(self, args):
-        """Query resource in use: query *IDN? """
+        """Query resource in use: query *IDN?"""
 
         if not self.current:
             print('There are no resources in use. Use the command "open".')
@@ -146,7 +146,7 @@ class VisaShell(cmd.Cmd):
             print(e)
 
     def do_write(self, args):
-        """Send to the resource in use: send *IDN? """
+        """Send to the resource in use: send *IDN?"""
 
         if not self.current:
             print('There are no resources in use. Use the command "open".')

--- a/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
@@ -556,7 +556,7 @@ class MessagebasedResourceTestCase(ResourceTestCase):
                 container=np.array if np else list,
             )
 
-            assert (not new.size if np else not new)
+            assert not new.size if np else not new
 
     def test_delay_in_query_ascii(self):
         """Test handling of the delay argument in query_ascii_values."""

--- a/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
@@ -459,7 +459,7 @@ class MessagebasedResourceTestCase(ResourceTestCase):
     # Not sure how to test this
     @pytest.mark.skip
     def test_handling_malformed_binary(self):
-        """"""
+        """ """
         pass
 
     @pytest.mark.parametrize("hfmt, header", zip(("ieee", "empty"), ("#0", "")))

--- a/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
@@ -524,7 +524,6 @@ class MessagebasedResourceTestCase(ResourceTestCase):
                 chunk_size=6,
             )
 
-    @pytest.mark.parametrize("hfmt, header", zip(("ieee"), ("#10", "")))
     def test_read_binary_values_empty(self):
         """Test reading binary data."""
         self.instr.write("RECEIVE")

--- a/pyvisa/testsuite/keysight_assisted_tests/test_resource_manager.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/test_resource_manager.py
@@ -50,6 +50,8 @@ class TestResourceManager:
             self.rm.session
         assert self.rm.visalib.resource_manager is None
 
+    # This test is flaky
+    @pytest.mark.skip
     def test_cleanup_on_del(self, caplog):
         """Test that deleting the rm does clean the VISA session"""
         # The test seems to assert what it should even though the coverage report

--- a/pyvisa/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -103,6 +103,11 @@ class TestTCPIPSocket(MessagebasedResourceTestCase):
             MessagebasedResourceTestCase.test_read_binary_values_unreported_length
         )
     )
+    test_read_binary_values_empty = pytest.mark.xfail(
+        copy_func(
+            MessagebasedResourceTestCase.test_read_binary_values_empty
+        )
+    )
     test_delay_in_query_ascii = pytest.mark.xfail(
         copy_func(MessagebasedResourceTestCase.test_delay_in_query_ascii)
     )

--- a/pyvisa/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -104,9 +104,7 @@ class TestTCPIPSocket(MessagebasedResourceTestCase):
         )
     )
     test_read_binary_values_empty = pytest.mark.xfail(
-        copy_func(
-            MessagebasedResourceTestCase.test_read_binary_values_empty
-        )
+        copy_func(MessagebasedResourceTestCase.test_read_binary_values_empty)
     )
     test_delay_in_query_ascii = pytest.mark.xfail(
         copy_func(MessagebasedResourceTestCase.test_delay_in_query_ascii)

--- a/pyvisa/testsuite/test_cmd_line_tools.py
+++ b/pyvisa/testsuite/test_cmd_line_tools.py
@@ -56,10 +56,8 @@ class TestCmdLineTools(BaseTestCase):
         result = run("pyvisa-info", stdout=PIPE, universal_newlines=True)
         details = util.system_details_to_str(util.get_system_details())
         # Path difference can lead to subtle differences in the backends
-        # compare only the first lines.
-        assert (
-            result.stdout.strip().split("\n")[:16] == details.strip().split("\n")[:16]
-        )
+        # and Python path so compare only the first lines.
+        assert result.stdout.strip().split("\n")[:5] == details.strip().split("\n")[:5]
 
     # TODO test backend selection: this is not easy at all to assert
     @require_visa_lib

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -161,7 +161,7 @@ class TestConfigFile(BaseTestCase):
 class TestParser(BaseTestCase):
     def test_parse_binary(self):
         s = (
-            b"#A@\xe2\x8b<@\xe2\x8b<@\xe2\x8b<@\xe2\x8b<@\xde\x8b<@\xde\x8b<@"
+            b"#0@\xe2\x8b<@\xe2\x8b<@\xe2\x8b<@\xe2\x8b<@\xde\x8b<@\xde\x8b<@"
             b"\xde\x8b<@\xde\x8b<@\xe0\x8b<@\xe0\x8b<@\xdc\x8b<@\xde\x8b<@"
             b"\xe2\x8b<@\xe0\x8b<"
         )
@@ -191,6 +191,10 @@ class TestParser(BaseTestCase):
         p = util.from_ieee_block(b"#214" + s[2:], datatype="f", is_big_endian=False)
         for a, b in zip(p, e):
             assert a == pytest.approx(b)
+
+        # Test handling zero length block
+        p = util.from_ieee_block(b"#10" + s[2:], datatype="f", is_big_endian=False)
+        assert not p
 
         p = util.from_hp_block(
             b"#A\x0e\x00" + s[2:],
@@ -377,7 +381,7 @@ class TestParser(BaseTestCase):
                 block = block[:2] + b"0" * header_length + block[2 + header_length :]
             else:
                 block = block[:2] + b"\x00\x00\x00\x00" + block[2 + 4 :]
-            assert fb(block, "h", False, list) == values
+            assert not fb(block, "h", False, list)
 
     def test_handling_malformed_binary(self):
         containers = (list, tuple) + ((np.array, np.ndarray) if np else ())

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -210,7 +210,8 @@ class TestParser(BaseTestCase):
         for fmt in "d":
             msg = "block=%s, fmt=%s"
             msg = msg % ("ascii", fmt)
-            tb = lambda values: util.to_ascii_block(values, fmt, ",")
+            # Test handling the case of a trailing comma
+            tb = lambda values: util.to_ascii_block(values, fmt, ",") + ","
             fb = lambda block, cont: util.from_ascii_block(block, fmt, ",", cont)
             self.round_trip_block_conversion(values, tb, fb, msg)
 

--- a/pyvisa/thirdparty/prettytable.py
+++ b/pyvisa/thirdparty/prettytable.py
@@ -938,7 +938,7 @@ class PrettyTable(object):
 
     @property
     def oldsortslice(self):
-        """ oldsortslice - Slice rows before sorting in the "old style" """
+        """oldsortslice - Slice rows before sorting in the "old style" """
         return self._oldsortslice
 
     @oldsortslice.setter

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -346,6 +346,8 @@ def from_ascii_block(
     data: Iterable[str]
     if isinstance(separator, str):
         data = ascii_data.split(separator)
+        if not data[-1]:
+            data = data[:-1]
     else:
         data = separator(ascii_data)
 

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -467,7 +467,7 @@ def parse_ieee_block_header(
     else:
         # #0DATA
         # 012
-        data_length = 0
+        data_length = -1
 
     return offset, data_length
 
@@ -577,7 +577,7 @@ def from_ieee_block(
 
     # If the data length is not reported takes all the data and do not make
     # any assumption about the termination character
-    if data_length == 0:
+    if data_length == -1:
         data_length = len(block) - offset
 
     if len(block) < offset + data_length:
@@ -626,11 +626,6 @@ def from_hp_block(
 
     """
     offset, data_length = parse_hp_block_header(block, is_big_endian)
-
-    # If the data length is not reported takes all the data and do not make
-    # any assumption about the termination character
-    if data_length == 0:
-        data_length = len(block) - offset
 
     if len(block) < offset + data_length:
         raise ValueError(


### PR DESCRIPTION
- [x] Closes #580 
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Added an entry to the CHANGES file

WAIT for Keysight buildbot to be up and running again.