### PR TITLE
ctwrapper: fix debug info collection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 PyVISA Changelog
 ================
 
+1.12.0 (unreleased)
+-------------------
+
+- fix collection of debug info on the ctypes wrapper PR #598
+
+
 1.11.3 (07-11-2020)
 -------------------
 

--- a/pyvisa/ctwrapper/highlevel.py
+++ b/pyvisa/ctwrapper/highlevel.py
@@ -128,12 +128,12 @@ class IVIVisaLibrary(highlevel.VisaLibraryBase):
                 )
                 nfo["Impl. Version"] = str(
                     lib.get_attribute(
-                        sess, constants.ResourceAttribute.resource_manufacturer_name
+                        sess, constants.ResourceAttribute.resource_impl_version
                     )[0]
                 )
                 nfo["Spec. Version"] = str(
                     lib.get_attribute(
-                        sess, constants.ResourceAttribute.resource_manufacturer_name
+                        sess, constants.ResourceAttribute.resource_spec_version
                     )[0]
                 )
                 lib.close(sess)


### PR DESCRIPTION
Correct the information for ctypes debug info (previously we were getting the manufacturer name 3 times !)