### PR TITLE
GPIB improve secondary address handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,17 +35,23 @@ jobs:
         run: |
           isort pyvisa -c;
       - name: Black
+        if: always()
         run: |
           black pyvisa --check;
       - name: Flake8
+        if: always()
         run: |
           flake8 pyvisa;
       - name: Mypy
+        if: always()
         run: |
           mypy pyvisa;
   tests:
     name: Unit tests
     runs-on: ${{ matrix.os }}
+    needs:
+      - formatting
+    if: needs.formatting.result == 'success'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/pyvisa/rname.py
+++ b/pyvisa/rname.py
@@ -7,7 +7,7 @@
 """
 import contextlib
 import re
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 from dataclasses import dataclass, field, fields
 from typing import (
     TYPE_CHECKING,
@@ -160,7 +160,7 @@ class ResourceName:
     is_rc_optional: ClassVar[bool] = False
 
     #: Formatting string for canonical
-    _canonical_fmt: str = field(init=False)
+    _canonical_fmt: dict[str, str] = field(init=False)
 
     #: VISA syntax for resource
     _visa_syntax: str = field(init=False)

--- a/pyvisa/rname.py
+++ b/pyvisa/rname.py
@@ -160,7 +160,7 @@ class ResourceName:
     is_rc_optional: ClassVar[bool] = False
 
     #: Formatting string for canonical
-    _canonical_fmt: dict[str, str] = field(init=False)
+    _canonical_fmt: Dict[str, str] = field(init=False)
 
     #: VISA syntax for resource
     _visa_syntax: str = field(init=False)

--- a/pyvisa/rname.py
+++ b/pyvisa/rname.py
@@ -7,7 +7,7 @@
 """
 import contextlib
 import re
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from dataclasses import dataclass, field, fields
 from typing import (
     TYPE_CHECKING,
@@ -98,23 +98,28 @@ T = TypeVar("T", bound=Type["ResourceName"])
 
 
 def register_subclass(cls: T) -> T:
-    """Register a subclass for a given interface type and resource class."""
+    """Register a subclass for a given interface type and resource class.
+
+    Fields with a default value of None will be fully omitted from the resource
+    string when formatted.
+
+    """
 
     # Assemble the format string based on the resource parts
-    fmt = cls.interface_type
+    fmt = OrderedDict([("interface_type", cls.interface_type)])
     syntax = cls.interface_type
     for ndx, f in enumerate(fields(cls)):
 
         sep = "::" if ndx else ""
 
-        fmt += sep + "{0.%s}" % f.name
+        fmt[f.name] = sep + "{0}"
 
-        if not f.default:
+        if f.default == "":
             syntax += sep + f.name.replace("_", " ")
         else:
             syntax += "[" + sep + f.name.replace("_", " ") + "]"
 
-    fmt += "::" + cls.resource_class
+    fmt["resource_class"] = "::" + cls.resource_class
 
     if not cls.is_rc_optional:
         syntax += "::" + cls.resource_class
@@ -169,7 +174,7 @@ class ResourceName:
     def __post_init__(self):
         # Ensure that all mandatory arguments have been passed
         for f in fields(self):
-            if not getattr(self, f.name):
+            if getattr(self, f.name) == "":
                 raise TypeError(f.name + " is a required parameter")
         self._fields = tuple(f.name for f in fields(self))
 
@@ -296,7 +301,7 @@ class ResourceName:
         # The rest of the parts are consumed when mandatory elements are required.
         while len(pending) < len(rp):
             k, rp = rp[0], rp[1:]
-            if not k.default:
+            if k.default == "":
                 # This is impossible as far as I can tell for currently implemented
                 # resource names
                 if not pending:
@@ -315,7 +320,12 @@ class ResourceName:
         return cls(**kwargs)
 
     def __str__(self):
-        return self._canonical_fmt.format(self)
+        s = ""
+        for part, form in self._canonical_fmt.items():
+            value = getattr(self, part, None)
+            if value is not None:
+                s += form.format(value)
+        return s
 
 
 # Build subclasses for each resource
@@ -340,7 +350,8 @@ class GPIBInstr(ResourceName):
     #: Secondary address of the device to connect to
     # Reference for the GPIB secondary address
     # https://www.mathworks.com/help/instrument/secondaryaddress.html
-    secondary_address: str = "0"
+    # NOTE: a secondary address of 0 is not the same as no secondary address.
+    secondary_address: Optional[str] = None
 
     interface_type: ClassVar[str] = "GPIB"
     resource_class: ClassVar[str] = "INSTR"
@@ -757,7 +768,11 @@ class _AttrGetter:
             if not isinstance(self.parsed, GPIBInstr):
                 raise self.raise_missing_attr(item)
             else:
-                return int(self.parsed.secondary_address)
+                return (
+                    int(self.parsed.secondary_address)
+                    if self.parsed.secondary_address is not None
+                    else constants.VI_NO_SEC_ADDR
+                )
         elif item == "VI_ATTR_PXI_CHASSIS":
             if not isinstance(self.parsed, PXIBackplane):
                 raise self.raise_missing_attr(item)

--- a/pyvisa/testsuite/test_rname.py
+++ b/pyvisa/testsuite/test_rname.py
@@ -97,7 +97,7 @@ class TestResourceName(BaseTestCase):
 
         # Test handling less than required parts
         with pytest.raises(rname.InvalidResourceName) as e:
-            rname.ResourceName.from_string("GPIB::INSTR")
+            rname.ResourceName.from_string("GPIB")
         assert "not enough parts" in e.exconly()
 
         # Test handling more than possible parts
@@ -212,8 +212,8 @@ class TestParsers(BaseTestCase):
             resource_class="INSTR",
             board="0",
             primary_address="1",
-            secondary_address="0",
-            canonical_resource_name="GPIB0::1::0::INSTR",
+            secondary_address=None,
+            canonical_resource_name="GPIB0::1::INSTR",
         )
 
         self._parse_test(
@@ -222,8 +222,8 @@ class TestParsers(BaseTestCase):
             resource_class="INSTR",
             board="1",
             primary_address="1",
-            secondary_address="0",
-            canonical_resource_name="GPIB1::1::0::INSTR",
+            secondary_address=None,
+            canonical_resource_name="GPIB1::1::INSTR",
         )
 
         self._parse_test(
@@ -232,8 +232,8 @@ class TestParsers(BaseTestCase):
             resource_class="INSTR",
             board="1",
             primary_address="1",
-            secondary_address="0",
-            canonical_resource_name="GPIB1::1::0::INSTR",
+            secondary_address=None,
+            canonical_resource_name="GPIB1::1::INSTR",
         )
 
     def test_gpib_intf(self):
@@ -439,7 +439,7 @@ class TestFilters(BaseTestCase):
         "USB0::0x1112::0x2223::0x1234::0::INSTR",
         "TCPIP0::192.168.0.1::inst1::INSTR",
         "TCPIP0::localhost::10001::SOCKET",
-        "GPIB9::7::65535::INSTR",
+        "GPIB9::7::1::INSTR",
         "ASRL11::INSTR",
         "ASRL2::INSTR",
         "GPIB::INTFC",
@@ -503,7 +503,10 @@ class TestFilters(BaseTestCase):
         self._test_filter2('?*{VI_ATTR_TCPIP_DEVICE_NAME == "inst1"}', 5)
         self._test_filter2("?*{VI_ATTR_TCPIP_PORT == 10001}", 6)
         self._test_filter2("?*{VI_ATTR_GPIB_PRIMARY_ADDR == 8}", 0)
-        self._test_filter2("?*{VI_ATTR_GPIB_SECONDARY_ADDR == 0}", 0)
+        self._test_filter2("?*{VI_ATTR_GPIB_SECONDARY_ADDR == 1}", 7)
+        self._test_filter2(
+            "?*{VI_ATTR_GPIB_SECONDARY_ADDR == %d}" % constants.VI_NO_SEC_ADDR, 0
+        )
         self._test_filter2("?*{VI_ATTR_PXI_CHASSIS == 1}", 11)
         self._test_filter2("?*{VI_ATTR_MAINFRAME_LA == 1}", 13, 14)
         self._test_filter2("?*{VI_ATTR_MAINFRAME_LA == 1 && VI_test == 1}", 13, 14)


### PR DESCRIPTION
If a resource does not use a GPIB device secondary address, it should be fully omitted from the resource name rather than set to 0. Setting the secondary address to 0 can cause issues with old instruments (see #640) and also cause issues when using low-level GPIB protocols (can't find the issue ATM).

@sixtemesseven could you review and tests as you offered to do in #640 