### PR TITLE
Remove duplicate call to shell.main

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,7 +30,7 @@ PyVISA Changelog
   Flow control attribute per ivi foundation definition is a flag and
   multiple flow control types can be set.
 - move all setup metadata to pyproject.toml PR #600
-- remove duplicate calls to the command loop after running pyvisa-shell
+- remove duplicate call to the command loop after running pyvisa-shell PR #687
 
 1.11.3 (07-11-2020)
 -------------------

--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ PyVISA Changelog
   Flow control attribute per ivi foundation definition is a flag and
   multiple flow control types can be set.
 - move all setup metadata to pyproject.toml PR #600
+- remove duplicate calls to the command loop after running pyvisa-shell
 
 1.11.3 (07-11-2020)
 -------------------

--- a/pyvisa/cmd_line_tools.py
+++ b/pyvisa/cmd_line_tools.py
@@ -51,8 +51,6 @@ def visa_main(command: Optional[str] = None) -> None:
         from pyvisa import shell
 
         shell.main("@" + args.backend if args.backend else "")
-
-        shell.main("@" + args.backend if args.backend else "")
     else:
         raise ValueError(
             f"Unknown command {args.command}. Valid values are: info and shell"

--- a/pyvisa/testsuite/test_cmd_line_tools.py
+++ b/pyvisa/testsuite/test_cmd_line_tools.py
@@ -40,4 +40,4 @@ class TestCmdLineTools(BaseTestCase):
         """Test the visa shell function."""
         with Popen(["pyvisa-shell"], stdin=PIPE, stdout=PIPE) as p:
             stdout, stderr = p.communicate(b"exit")
-        assert b"Welcome to the VISA shell" in stdout
+        assert stdout.count(b"Welcome to the VISA shell") == 1


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to PyVISA :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy. You can also use pre-commit hooks (see the
   developer documentation for detailed instructions)

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

Removes a double call to `shell.main` in `cmd_line_tools.py`.

Before the change, calling `exit` from `pyvisa-shell` results in a re-entry of the command loop.  `exit` has to be called twice.

<img width="434" alt="image" src="https://user-images.githubusercontent.com/51342134/185225966-9325f758-f050-430a-a262-b646e4d1d4ff.png">

After this change:

<img width="505" alt="image" src="https://user-images.githubusercontent.com/51342134/185226053-b1639158-756b-4eaf-b872-b223b2afdd8a.png">
