### PR TITLE
read_termination_context uses read_termination logic

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ PyVISA Changelog
 1.14.0 (unreleased)
 -------------------
 - fix ctypes truncated pointers on 64-bit for ViBusAddress, ViBusSize, ViAttrState PR # 725
+- fix read_termination_context does not allow None PR # 727
 
 1.13.0 (22-12-2022)
 -------------------

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -773,12 +773,10 @@ class MessageBasedResource(Resource):
 
     @contextlib.contextmanager
     def read_termination_context(self, new_termination: str) -> Iterator:
-        term = self.get_visa_attribute(constants.ResourceAttribute.termchar)
-        self.set_visa_attribute(
-            constants.ResourceAttribute.termchar, ord(new_termination[-1])
-        )
+        term = self.read_termination
+        self.read_termination = new_termination
         yield
-        self.set_visa_attribute(constants.ResourceAttribute.termchar, term)
+        self.read_termination = term
 
     def flush(self, mask: constants.BufferOperation) -> None:
         """Manually clears the specified buffers.


### PR DESCRIPTION
Problem was, that the read_termination_context did not accept None for no read_termination.

Changes:
- Logic of `read_termination.setter` moved to a new method (without setting private attribute `_read_termination`).
- `read_termination_context` uses that new method to set the termination before and after yield.

Open question:
Right now, the private attribute `_read_termination` (returned by public property `read_termination`) remains the original one.
If you prefer, we could change that, such that the method looks this:
~~~python
def read_termination_context(self, value):
    term = self.read_termination
    yield
    self.read_termination = term
~~~

- [x] Closes #723 (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests (there are no test_files for `messagebased` yet)
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
