### PR TITLE
Fix dataclass hierarchy uncovered by mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991 # Use the sha / tag you want to point at
+    rev: v1.1.1 # Use the sha / tag you want to point at
     hooks:
       - id: mypy
         additional_dependencies: [numpy, typing_extensions]

--- a/pyvisa/rname.py
+++ b/pyvisa/rname.py
@@ -5,7 +5,6 @@
 :license: MIT, see LICENSE for more details.
 
 """
-from __future__ import annotations
 
 import contextlib
 import re
@@ -53,7 +52,7 @@ class InvalidResourceName(ValueError):
     @classmethod
     def bad_syntax(
         cls, syntax: str, resource_name: str, ex: Optional[Exception] = None
-    ) -> InvalidResourceName:
+    ) -> Self:
         """Build an exception when the resource name cannot be parsed."""
         if ex:
             msg = "The syntax is '%s' (%s)." % (syntax, ex)
@@ -69,7 +68,7 @@ class InvalidResourceName(ValueError):
         cls,
         interface_type_resource_class: Tuple[str, str],
         resource_name: Optional[str] = None,
-    ) -> InvalidResourceName:
+    ) -> Self:
         """Build an exception when no parser has been registered for a pair."""
 
         msg = "Parser not found for: %s." % (interface_type_resource_class,)
@@ -82,7 +81,7 @@ class InvalidResourceName(ValueError):
     @classmethod
     def rc_notfound(
         cls, interface_type: str, resource_name: Optional[str] = None
-    ) -> InvalidResourceName:
+    ) -> Self:
         """Build an exception when no resource class is provided and no default is found."""
 
         msg = (

--- a/pyvisa/rname.py
+++ b/pyvisa/rname.py
@@ -737,7 +737,7 @@ class _AttrGetter:
     """
 
     def __init__(
-        self, resource_name: str, open_resource: Callable[[str], Resource]
+        self, resource_name: str, open_resource: Callable[[str], "Resource"]
     ) -> None:
         self.resource_name = resource_name
         self.parsed = parse_resource_name(resource_name)
@@ -820,7 +820,7 @@ class _AttrGetter:
 
 
 def filter2(
-    resources: Iterable[str], query: str, open_resource: Callable[[str], Resource]
+    resources: Iterable[str], query: str, open_resource: Callable[[str], "Resource"]
 ) -> Tuple[str, ...]:
     """Filter a list of resources according to a query expression.
 

--- a/pyvisa/testsuite/test_rname.py
+++ b/pyvisa/testsuite/test_rname.py
@@ -162,7 +162,7 @@ class TestResourceName(BaseTestCase):
 
 
 class TestParsers(BaseTestCase):
-    def _parse_test(self, rn: str, **kwargs):
+    def _parse_test(self, rn, **kwargs):
         p = rname.ResourceName.from_string(rn)
         r = dict(
             (k, getattr(p, k)) for k in p._fields + ("interface_type", "resource_class")

--- a/pyvisa/testsuite/test_rname.py
+++ b/pyvisa/testsuite/test_rname.py
@@ -162,7 +162,7 @@ class TestResourceName(BaseTestCase):
 
 
 class TestParsers(BaseTestCase):
-    def _parse_test(self, rn, **kwargs):
+    def _parse_test(self, rn: str, **kwargs):
         p = rname.ResourceName.from_string(rn)
         r = dict(
             (k, getattr(p, k)) for k in p._fields + ("interface_type", "resource_class")


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to PyVISA :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy. You can also use pre-commit hooks (see the
   developer documentation for detailed instructions)

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

Split out of https://github.com/pyvisa/pyvisa/pull/733 since fix ended up being a bit involved.

`mypy` was complaining about bound typevar https://github.com/pyvisa/pyvisa/blob/df50969b3527ccfa28ae7e67b2be7468865bd3e2/pyvisa/rname.py#L99 being too loose, which was true. However, we couldn't just make `ResourceName` a dataclass since it'd bring a bunch of unneeded fields into children, which was breaking all of the logics.

I ended up separating things that needed to not be in a dataclass into a separate private parent class, with `ResourceName` becoming a dataclass as it should've been.

There are opportunities to make it a bit more elegant, but I'd rather discuss that separately.

- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
