### PR TITLE
resources: Update context manager type annotation to preserve derived type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ PyVISA Changelog
     have been removed
   - `p.u.get_shared_library_arch` now returns `p.u.PEMachineType` instead of a string
   - `p.u.get_arch` now returns a list of `p.u.ArchitectureType`
+- update `Resource` context manager type annotation to preserve derived type PR # 740
 
 1.13.0 (22-12-2022)
 -------------------

--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -184,7 +184,7 @@ class Resource(object):
     def __repr__(self) -> str:
         return "<%r(%r)>" % (self.__class__.__name__, self._resource_name)
 
-    def __enter__(self) -> "Resource":
+    def __enter__(self: T) -> T:
         return self
 
     def __exit__(self, *args) -> None:


### PR DESCRIPTION
The type annotation for `Resource.__enter__()` indicates that it returns the base class, `Resource`. If you narrow the resource type to a derived class before entering the context manager, entering the context manager casts it back to the base class.

The solution is to use a type var to specify that the return type is the same as the type of `self`.

<!--

Thanks for wanting to contribute to PyVISA :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   black, isort, flake8 and mypy. You can also use pre-commit hooks (see the
   developer documentation for detailed instructions)

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [x] Closes #739 
- [ ] Executed ``black . && isort -c . && flake8`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
