### PR TITLE
mention session sharing in ResourceManager.close docstring

### DIFF
--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -3063,7 +3063,15 @@ class ResourceManager(object):
         return self.visalib.get_last_status_in_session(self.session)
 
     def close(self) -> None:
-        """Close the resource manager session."""
+        """Close the resource manager session.
+
+        Notes
+        -----
+        Since the resource manager session is shared between instances
+        this will also terminate connections obtained from other
+        ResourceManager instances.
+
+        """
         atexit.unregister(self._atexit_handler)
         try:
             logger.debug("Closing ResourceManager (session: %s)", self.session)


### PR DESCRIPTION
Add a note in the docstring of ResourceManager.close to hint the user to the fact that this closes all shared resource manager connections.

Closes #742 
