### PR TITLE
Add support for custom simulated file backends in shell

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ PyVISA Changelog
   - `p.u.get_shared_library_arch` now returns `p.u.PEMachineType` instead of a string
   - `p.u.get_arch` now returns a list of `p.u.ArchitectureType`
 - update `Resource` context manager type annotation to preserve derived type PR # 740
+- added support for using custom simulation files when using the `sim` backend
+  with `pyvisa-shell`. PR #774
 
 1.13.0 (22-12-2022)
 -------------------

--- a/docs/source/introduction/shell.rst
+++ b/docs/source/introduction/shell.rst
@@ -158,6 +158,10 @@ You can invoke::
 to use python-sim as backend instead of ni backend.
 This can be used for example for testing of python-sim configuration.
 
+You can include a specific file to use for the simulated backend::
+
+    pyvisa-shell -b file.yaml@sim
+
 You can invoke::
 
     pyvisa-shell -b py

--- a/pyvisa/cmd_line_tools.py
+++ b/pyvisa/cmd_line_tools.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+import argparse
 from typing import Optional
 
 
@@ -50,11 +51,25 @@ def visa_main(command: Optional[str] = None) -> None:
     elif args.command == "shell":
         from pyvisa import shell
 
-        shell.main("@" + args.backend if args.backend else "")
+        backend = _create_backend_str(args)
+        shell.main(backend)
     else:
         raise ValueError(
             f"Unknown command {args.command}. Valid values are: info and shell"
         )
+
+
+def _create_backend_str(args: argparse.Namespace) -> str:
+    """Create the backend string from the CLI arguments."""
+    if not args.backend:
+        return ""
+
+    # User already entered things correctly like "@py" or "file.yaml@sim"
+    if "@" in args.backend:
+        return args.backend
+
+    # Keep the current functionality
+    return "@" + args.backend
 
 
 def visa_shell() -> None:

--- a/pyvisa/testsuite/test_cmd_line_tools.py
+++ b/pyvisa/testsuite/test_cmd_line_tools.py
@@ -2,12 +2,13 @@
 """Test the behavior of the command line tools.
 
 """
+import argparse
 import sys
 from subprocess import PIPE, Popen, run
 
 import pytest
 
-from pyvisa import util
+from pyvisa import cmd_line_tools, util
 
 from . import BaseTestCase, require_visa_lib
 
@@ -41,3 +42,18 @@ class TestCmdLineTools(BaseTestCase):
         with Popen(["pyvisa-shell"], stdin=PIPE, stdout=PIPE) as p:
             stdout, stderr = p.communicate(b"exit")
         assert stdout.count(b"Welcome to the VISA shell") == 1
+
+
+@pytest.mark.parametrize(
+    "args, want",
+    [
+        (argparse.Namespace(backend=None), ""),
+        (argparse.Namespace(backend="py"), "@py"),
+        (argparse.Namespace(backend="foo.yaml@sim"), "foo.yaml@sim"),
+        (argparse.Namespace(backend="/foo/bar/baz.yaml@sim"), "/foo/bar/baz.yaml@sim"),
+        (argparse.Namespace(backend="@sim"), "@sim"),
+    ],
+)
+def test__create_backend_str(args: argparse.Namespace, want: str) -> None:
+    got = cmd_line_tools._create_backend_str(args)
+    assert got == want


### PR DESCRIPTION
Fixes #773.

Add support for custom simulated instrument files when using `pyvisa-shell -b sim`:

```console
$ pyvisa-shell -b my_file.yaml@sim
```

- [x] Closes #773
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
