### PR TITLE
highlevel: allow missing board number which is the case for VICP

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 PyVISA Changelog
 ================
 
+1.14.1 (22-11-2023)
+-------------------
+- fix handling of missing board number for VICP resources PR #787
+
 1.14.0 (13-11-2023)
 -------------------
 - fix ctypes truncated pointers on 64-bit for ViBusAddress, ViBusSize, ViAttrState PR #725

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -2053,8 +2053,9 @@ class VisaLibraryBase(object):
                 else parsed.interface  # type: ignore
             )
         # In some cases the board number may not be convertible to an int
-        # PyVISA-py serial resources on Linux for example
-        except ValueError:
+        # PyVISA-py serial resources on Linux for example. For VICP, there is
+        # no such attribute.
+        except (ValueError, AttributeError):
             board_number = None
 
         return (


### PR DESCRIPTION
Closes #786 

@kimbyungnam can you test ?