### PR TITLE
Prevent duplicate paths from being added to the DLL paths

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,9 +4,11 @@ PyVISA Changelog
 1.15.0 (unreleased)
 -------------------
 - added support for an optional monitoring interface object to the read_binary_values() and
-    query_binary_values() methods of message-based resources.
+  query_binary_values() methods of message-based resources.
 - added the message_size() helper function to calculate the estimated size of a data
-    transfer, including the header.
+  transfer, including the header.
+- prevent adding duplicate paths to the DLL search path during ResourceManager
+  instantiation #811
 
 1.14.1 (22-11-2023)
 -------------------

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -18,6 +18,7 @@ from types import ModuleType
 from typing import Optional
 
 import pytest
+from pytest import LogCaptureFixture, MonkeyPatch
 
 from pyvisa import highlevel, util
 from pyvisa.ctwrapper import IVIVisaLibrary
@@ -45,7 +46,7 @@ class TestConfigFile(BaseTestCase):
             ]
         ):
             raise unittest.SkipTest(
-                ".pyvisarc file exists cannot properly test in this case"
+                ".pyvisarc file exists; cannot properly test in this case"
             )
         self.temp_dir = tempfile.TemporaryDirectory()
         os.makedirs(os.path.join(self.temp_dir.name, "share", "pyvisa"))
@@ -95,60 +96,137 @@ class TestConfigFile(BaseTestCase):
 
     # --- Test reading dll_extra_paths.
 
-    def test_reading_config_file_not_windows(self, caplog):
+    def test_reading_config_file_not_windows(self, caplog: LogCaptureFixture):
         sys.platform = "darwin"
+        sys.version_info = (3, 12, 1)  # type: ignore[assignment]
+
         with caplog.at_level(level=logging.DEBUG):
             assert util.add_user_dll_extra_paths() is None
         assert "Not loading dll_extra_paths" in caplog.records[0].message
 
-    def test_reading_config_file_for_dll_extra_paths(self, monkeypatch):
+    def test_reading_config_file_for_dll_extra_paths(self, monkeypatch: MonkeyPatch):
         sys.platform = "win32"
+        extra_paths = [
+            r"C:\Program Files",
+            r"C:\Program Files (x86)",
+        ]
+        added_dll_directories: list[str] = []
         monkeypatch.setattr(
-            os, "add_dll_directory", lambda *args, **kwargs: "", raising=False
+            os,
+            "add_dll_directory",
+            lambda path: added_dll_directories.append(path),
+            raising=False,
         )
         config = ConfigParser()
         config["Paths"] = {}
         config["Paths"]["dll_extra_paths"] = r"C:\Program Files;C:\Program Files (x86)"
+
         with open(self.config_path, "w") as f:
             config.write(f)
-        assert util.add_user_dll_extra_paths() == [
+
+        assert util.add_user_dll_extra_paths() == extra_paths
+        assert added_dll_directories == extra_paths
+
+    def test_reading_config_file_for_dll_extra_paths_multiple_times(
+        self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+    ):
+        sys.platform = "win32"
+        sys.version_info = (3, 8, 1)  # type: ignore[assignment]
+
+        iter_count = 5
+        extra_paths = [
             r"C:\Program Files",
             r"C:\Program Files (x86)",
         ]
-
-    def test_no_section_for_dll_extra_paths(self, monkeypatch, caplog):
-        sys.platform = "win32"
+        added_dll_directories: list[str] = []
         monkeypatch.setattr(
-            os, "add_dll_directory", lambda *args, **kwargs: "", raising=False
-        )
-        config = ConfigParser()
-        with open(self.config_path, "w") as f:
-            config.write(f)
-        with caplog.at_level(level=logging.DEBUG):
-            assert util.add_user_dll_extra_paths() is None
-        assert "NoOptionError or NoSectionError" in caplog.records[1].message
-
-    def test_no_key_for_dll_extra_paths(self, monkeypatch, caplog):
-        sys.platform = "win32"
-        monkeypatch.setattr(
-            os, "add_dll_directory", lambda *args, **kwargs: "", raising=False
+            os,
+            "add_dll_directory",
+            lambda path: added_dll_directories.append(path),
+            raising=False,
         )
         config = ConfigParser()
         config["Paths"] = {}
+        config["Paths"]["dll_extra_paths"] = r"C:\Program Files;C:\Program Files (x86)"
+
         with open(self.config_path, "w") as f:
             config.write(f)
+
+        with caplog.at_level(level=logging.DEBUG):
+            for _ in range(iter_count):
+                assert util.add_user_dll_extra_paths() == extra_paths
+        skipping_log_messages = [
+            rec.message
+            for rec in caplog.records
+            if "already added; skipping" in rec.message
+        ]
+        assert added_dll_directories == extra_paths
+        # one log message per path per iteration, except initial add
+        assert (iter_count - 1) * len(extra_paths) == len(skipping_log_messages)
+
+    def test_no_section_for_dll_extra_paths(
+        self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+    ):
+        sys.platform = "win32"
+        sys.version_info = (3, 8, 1)  # type: ignore[assignment]
+
+        added_dll_directories: list[str] = []
+        monkeypatch.setattr(
+            os,
+            "add_dll_directory",
+            lambda path: added_dll_directories.append(path),
+            raising=False,
+        )
+        config = ConfigParser()
+
+        with open(self.config_path, "w") as f:
+            config.write(f)
+
         with caplog.at_level(level=logging.DEBUG):
             assert util.add_user_dll_extra_paths() is None
         assert "NoOptionError or NoSectionError" in caplog.records[1].message
+        assert added_dll_directories == []
 
-    def test_no_config_file_for_dll_extra_paths(self, monkeypatch, caplog):
+    def test_no_key_for_dll_extra_paths(
+        self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+    ):
         sys.platform = "win32"
+        added_dll_directories: list[str] = []
         monkeypatch.setattr(
-            os, "add_dll_directory", lambda *args, **kwargs: "", raising=False
+            os,
+            "add_dll_directory",
+            lambda path: added_dll_directories.append(path),
+            raising=False,
         )
+        config = ConfigParser()
+        config["Paths"] = {}
+
+        with open(self.config_path, "w") as f:
+            config.write(f)
+
+        with caplog.at_level(level=logging.DEBUG):
+            assert util.add_user_dll_extra_paths() is None
+        assert "NoOptionError or NoSectionError" in caplog.records[1].message
+        assert added_dll_directories == []
+
+    def test_no_config_file_for_dll_extra_paths(
+        self, monkeypatch: MonkeyPatch, caplog: LogCaptureFixture
+    ):
+        sys.platform = "win32"
+        sys.version_info = (3, 8, 1)  # type: ignore[assignment]
+
+        added_dll_directories: list[str] = []
+        monkeypatch.setattr(
+            os,
+            "add_dll_directory",
+            lambda path: added_dll_directories.append(path),
+            raising=False,
+        )
+
         with caplog.at_level(level=logging.DEBUG):
             assert util.add_user_dll_extra_paths() is None
         assert "No user defined" in caplog.records[0].message
+        assert added_dll_directories == []
 
 
 class TestParser(BaseTestCase):

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -57,6 +57,7 @@ class TestConfigFile(BaseTestCase):
         sys.prefix = self.temp_dir.name
         self._platform = sys.platform
         self._version_info = sys.version_info
+        util._ADDED_DLL_PATHS = set()
 
     def teardown_method(self):
         self.temp_dir.cleanup()
@@ -158,7 +159,7 @@ class TestConfigFile(BaseTestCase):
         skipping_log_messages = [
             rec.message
             for rec in caplog.records
-            if "already added; skipping" in rec.message
+            if "already been added; skipping" in rec.message
         ]
         assert added_dll_directories == extra_paths
         # one log message per path per iteration, except initial add

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -129,7 +129,6 @@ def add_user_dll_extra_paths() -> Optional[List[str]]:
     """
     from configparser import ConfigParser, NoOptionError, NoSectionError
 
-    # os.add_dll_library_path has been added in Python 3.8
     if sys.platform == "win32":
         config_parser = ConfigParser()
         files = config_parser.read(
@@ -158,8 +157,7 @@ def add_user_dll_extra_paths() -> Optional[List[str]]:
             return None
     else:
         logger.debug(
-            "Not loading dll_extra_paths because we are not on Windows "
-            "or Python < 3.8"
+            "Not loading dll_extra_paths because we are not on Windows"
         )
         return None
 

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -164,9 +164,7 @@ def add_user_dll_extra_paths() -> Optional[List[str]]:
             )
             return None
     else:
-        logger.debug(
-            "Not loading dll_extra_paths because we are not on Windows"
-        )
+        logger.debug("Not loading dll_extra_paths because we are not on Windows")
         return None
 
 


### PR DESCRIPTION
This PR adds very rudimentary tracking of dll paths we already added in order to prevent exceeding path length limit if we create `ResourceManager`s in a loop.

- [x] Closes #807
- [x] Executed ``black . && isort -c . && flake8`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
