### PR TITLE
Apply latest `ruff format` + update pre-commit hooks to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.1.6
+  rev: v0.3.4
   hooks:
     # Run the linter.
     - id: ruff
     # Run the formatter.
     - id: ruff-format
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.7.0
+  rev: v1.9.0
   hooks:
     - id: mypy
       additional_dependencies: [numpy, typing_extensions]

--- a/pyvisa/__init__.py
+++ b/pyvisa/__init__.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import logging
 from importlib.metadata import PackageNotFoundError, version
 

--- a/pyvisa/attributes.py
+++ b/pyvisa/attributes.py
@@ -10,6 +10,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import enum
 import sys
 from collections import defaultdict

--- a/pyvisa/cmd_line_tools.py
+++ b/pyvisa/cmd_line_tools.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import argparse
 from typing import Optional
 

--- a/pyvisa/constants.py
+++ b/pyvisa/constants.py
@@ -13,6 +13,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import enum
 import sys
 

--- a/pyvisa/ctwrapper/__init__.py
+++ b/pyvisa/ctwrapper/__init__.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import os
 
 from .highlevel import IVIVisaLibrary

--- a/pyvisa/ctwrapper/cthelper.py
+++ b/pyvisa/ctwrapper/cthelper.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import ctypes
 import os
 import sys

--- a/pyvisa/ctwrapper/functions.py
+++ b/pyvisa/ctwrapper/functions.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import warnings
 from contextlib import contextmanager
 from ctypes import (

--- a/pyvisa/ctwrapper/highlevel.py
+++ b/pyvisa/ctwrapper/highlevel.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import ctypes
 import logging
 from collections import OrderedDict
@@ -144,9 +145,9 @@ class IVIVisaLibrary(highlevel.VisaLibraryBase):
             except Exception as e:
                 err_string = str(e)
                 if "No matching architecture" in err_string:
-                    nfo[
-                        "Could not get more info"
-                    ] = "Interpreter and library have different bitness."
+                    nfo["Could not get more info"] = (
+                        "Interpreter and library have different bitness."
+                    )
                 else:
                     nfo["Could not get more info"] = err_string.split("\n")
 

--- a/pyvisa/ctwrapper/types.py
+++ b/pyvisa/ctwrapper/types.py
@@ -12,6 +12,7 @@ means "ViUInt32" and such.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import ctypes as _ctypes
 import sys
 

--- a/pyvisa/errors.py
+++ b/pyvisa/errors.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from typing import Any, Tuple
 
 from . import typing, util

--- a/pyvisa/events.py
+++ b/pyvisa/events.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from typing import TYPE_CHECKING, Callable, Dict, Optional, Type
 
 from typing_extensions import ClassVar
@@ -150,9 +151,9 @@ class GPIBCICEvent(Event):
     """
 
     #: New state of the controller in charge status
-    cic_state: Attribute[
-        constants.LineState
-    ] = attributes.AttrVI_ATTR_GPIB_RECV_CIC_STATE()
+    cic_state: Attribute[constants.LineState] = (
+        attributes.AttrVI_ATTR_GPIB_RECV_CIC_STATE()
+    )
 
 
 @Event.register(constants.EventType.io_completion)
@@ -186,9 +187,9 @@ class TrigEvent(Event):
 
     #: Identifier of the triggering mechanism on which the specified trigger event
     #: was received.
-    received_trigger_id: Attribute[
-        constants.TriggerID
-    ] = attributes.AttrVI_ATTR_TRIG_ID()
+    received_trigger_id: Attribute[constants.TriggerID] = (
+        attributes.AttrVI_ATTR_TRIG_ID()
+    )
 
 
 @Event.register(constants.EventType.usb_interrupt)

--- a/pyvisa/highlevel.py
+++ b/pyvisa/highlevel.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import atexit
 import contextlib
 import copy

--- a/pyvisa/resources/__init__.py
+++ b/pyvisa/resources/__init__.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from .firewire import FirewireInstrument
 from .gpib import GPIBInstrument, GPIBInterface
 from .messagebased import MessageBasedResource

--- a/pyvisa/resources/firewire.py
+++ b/pyvisa/resources/firewire.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from .. import constants
 from .registerbased import RegisterBasedResource
 

--- a/pyvisa/resources/gpib.py
+++ b/pyvisa/resources/gpib.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from enum import Enum
 from time import perf_counter
 from typing import Tuple
@@ -56,13 +57,13 @@ class GPIBCommand(bytes, Enum):
     serial_poll_disable = SPD = b"\x19"
 
     #: CFE: CONFIGURE ENABLE
-    configure_enable = CFE = b"\x1F"
+    configure_enable = CFE = b"\x1f"
 
     #: UNT: UNTALK
-    untalk = UNT = b"\x3F"
+    untalk = UNT = b"\x3f"
 
     #: UNL: UNLISTEN
-    unlisten = UNL = b"\x5F"
+    unlisten = UNL = b"\x5f"
 
     @staticmethod
     def talker(board_pad) -> bytes:
@@ -102,9 +103,9 @@ class _GPIBMixin(ControlRenMixin):
     secondary_address: Attribute[int] = attributes.AttrVI_ATTR_GPIB_SECONDARY_ADDR()
 
     #: Current state of the GPIB REN (Remote ENable) interface line.
-    remote_enabled: Attribute[
-        constants.LineState
-    ] = attributes.AttrVI_ATTR_GPIB_REN_STATE()
+    remote_enabled: Attribute[constants.LineState] = (
+        attributes.AttrVI_ATTR_GPIB_REN_STATE()
+    )
 
 
 @Resource.register(constants.InterfaceType.gpib, "INSTR")
@@ -179,9 +180,9 @@ class GPIBInterface(_GPIBMixin, MessageBasedResource):
     """
 
     #: Is the specified GPIB interface currently the system controller.
-    is_system_controller: Attribute[
-        bool
-    ] = attributes.AttrVI_ATTR_GPIB_SYS_CNTRL_STATE()
+    is_system_controller: Attribute[bool] = (
+        attributes.AttrVI_ATTR_GPIB_SYS_CNTRL_STATE()
+    )
 
     #: Is the specified GPIB interface currently CIC (Controller In Charge).
     is_controller_in_charge: Attribute[bool] = attributes.AttrVI_ATTR_GPIB_CIC_STATE()
@@ -190,14 +191,14 @@ class GPIBInterface(_GPIBMixin, MessageBasedResource):
     atn_state: Attribute[constants.LineState] = attributes.AttrVI_ATTR_GPIB_ATN_STATE()
 
     #: Current state of the GPIB NDAC (Not Data ACcepted) interface line.
-    ndac_state: Attribute[
-        constants.LineState
-    ] = attributes.AttrVI_ATTR_GPIB_NDAC_STATE()
+    ndac_state: Attribute[constants.LineState] = (
+        attributes.AttrVI_ATTR_GPIB_NDAC_STATE()
+    )
 
     #: Is the GPIB interface currently addressed to talk or listen, or is not addressed.
-    address_state: Attribute[
-        constants.LineState
-    ] = attributes.AttrVI_ATTR_GPIB_ADDR_STATE()
+    address_state: Attribute[constants.LineState] = (
+        attributes.AttrVI_ATTR_GPIB_ADDR_STATE()
+    )
 
     def group_execute_trigger(
         self, *resources: GPIBInstrument

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import contextlib
 import struct
 import time

--- a/pyvisa/resources/pxi.py
+++ b/pyvisa/resources/pxi.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from .. import attributes, constants
 from ..attributes import Attribute
 from .registerbased import RegisterBasedResource

--- a/pyvisa/resources/registerbased.py
+++ b/pyvisa/resources/registerbased.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from typing import Iterable, List
 
 from .. import constants

--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import contextlib
 import time
 from functools import update_wrapper
@@ -212,9 +213,9 @@ class Resource(object):
     # resource_manager_session: Attribute[int] = attributes.AttrVI_ATTR_RM_SESSION()
 
     #: Interface type of the given session.
-    interface_type: Attribute[
-        constants.InterfaceType
-    ] = attributes.AttrVI_ATTR_INTF_TYPE()
+    interface_type: Attribute[constants.InterfaceType] = (
+        attributes.AttrVI_ATTR_INTF_TYPE()
+    )
 
     #: Board number for the given interface.
     interface_number: Attribute[int] = attributes.AttrVI_ATTR_INTF_NUM()
@@ -229,9 +230,9 @@ class Resource(object):
     implementation_version: Attribute[int] = attributes.AttrVI_ATTR_RSRC_IMPL_VERSION()
 
     #: Current locking state of the resource.
-    lock_state: Attribute[
-        constants.AccessModes
-    ] = attributes.AttrVI_ATTR_RSRC_LOCK_STATE()
+    lock_state: Attribute[constants.AccessModes] = (
+        attributes.AttrVI_ATTR_RSRC_LOCK_STATE()
+    )
 
     #: Version of the VISA specification to which the implementation is compliant.
     spec_version: Attribute[int] = attributes.AttrVI_ATTR_RSRC_SPEC_VERSION()

--- a/pyvisa/resources/serial.py
+++ b/pyvisa/resources/serial.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from .. import attributes, constants
 from ..attributes import Attribute
 from .messagebased import MessageBasedResource
@@ -37,9 +38,9 @@ class SerialInstrument(MessageBasedResource):
 
     #: Indicates the type of flow control used by the transfer mechanism. The default value
     #: is `constants.ControlFlow.none` (VI_ASRL_FLOW_NONE).
-    flow_control: Attribute[
-        constants.ControlFlow
-    ] = attributes.AttrVI_ATTR_ASRL_FLOW_CNTRL()
+    flow_control: Attribute[constants.ControlFlow] = (
+        attributes.AttrVI_ATTR_ASRL_FLOW_CNTRL()
+    )
 
     #: Number of bytes available in the low- level I/O receive buffer.
     bytes_in_buffer: Attribute[int] = attributes.AttrVI_ATTR_ASRL_AVAIL_NUM()
@@ -52,25 +53,25 @@ class SerialInstrument(MessageBasedResource):
 
     #: Method used to terminate read operations. The default value is
     #: `constants.SerialTermination.termination_char` (VI_ASRL_END_TERMCHAR).
-    end_input: Attribute[
-        constants.SerialTermination
-    ] = attributes.AttrVI_ATTR_ASRL_END_IN()
+    end_input: Attribute[constants.SerialTermination] = (
+        attributes.AttrVI_ATTR_ASRL_END_IN()
+    )
 
     #: Method used to terminate write operations. The default value is
     #: `constants.SerialTermination.none` (VI_ASRL_END_NONE) and terminates
     #: when all requested data is transferred or when an error occurs.
-    end_output: Attribute[
-        constants.SerialTermination
-    ] = attributes.AttrVI_ATTR_ASRL_END_OUT()
+    end_output: Attribute[constants.SerialTermination] = (
+        attributes.AttrVI_ATTR_ASRL_END_OUT()
+    )
 
     #: Duration (in milliseconds) of the break signal. The default value is 250.
     break_length: Attribute[int] = attributes.AttrVI_ATTR_ASRL_BREAK_LEN()
 
     #: Manually control the assertion state of the break signal. The default state is
     #: `constants.LineState.unasserted` (VI_STATE_UNASSERTED).
-    break_state: Attribute[
-        constants.LineState
-    ] = attributes.AttrVI_ATTR_ASRL_BREAK_STATE()
+    break_state: Attribute[constants.LineState] = (
+        attributes.AttrVI_ATTR_ASRL_BREAK_STATE()
+    )
 
     #: Character to be used to replace incoming characters that arrive with errors.
     #: The default character is '\0'.

--- a/pyvisa/resources/tcpip.py
+++ b/pyvisa/resources/tcpip.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from .. import constants
 from .messagebased import ControlRenMixin, MessageBasedResource
 from .resource import Resource

--- a/pyvisa/resources/usb.py
+++ b/pyvisa/resources/usb.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from .. import attributes, constants
 from ..attributes import Attribute
 from .messagebased import ControlRenMixin, MessageBasedResource

--- a/pyvisa/resources/vxi.py
+++ b/pyvisa/resources/vxi.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from .. import attributes, constants
 from ..attributes import Attribute
 from .registerbased import RegisterBasedResource

--- a/pyvisa/shell.py
+++ b/pyvisa/shell.py
@@ -8,6 +8,7 @@ This file is taken from the Lantz Project.
 :license: BSD, see LICENSE for more details.
 
 """
+
 import cmd
 from typing import List, Tuple
 

--- a/pyvisa/testsuite/__init__.py
+++ b/pyvisa/testsuite/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""PyVISA testsuite.
+"""PyVISA testsuite."""
 
-"""
 import logging
 from logging.handlers import BufferingHandler
 

--- a/pyvisa/testsuite/fake-extensions/pyvisa_test.py
+++ b/pyvisa/testsuite/fake-extensions/pyvisa_test.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""
+""" """
 
-"""
 from pyvisa.highlevel import VisaLibraryBase
 
 

--- a/pyvisa/testsuite/fake-extensions/pyvisa_test_open.py
+++ b/pyvisa/testsuite/fake-extensions/pyvisa_test_open.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""
+""" """
 
-"""
 from pyvisa import constants
 from pyvisa.highlevel import VisaLibraryBase
 from pyvisa.util import LibraryPath

--- a/pyvisa/testsuite/keysight_assisted_tests/__init__.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/__init__.py
@@ -16,6 +16,7 @@ coverage.process_startup()
 See https://coverage.readthedocs.io/en/v4.5.x/subprocess.html for details.
 
 """
+
 import functools
 import os
 import types

--- a/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/messagebased_resource_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Common test case for all message based resources.
+"""Common test case for all message based resources."""
 
-"""
 import ctypes
 import gc
 import logging

--- a/pyvisa/testsuite/keysight_assisted_tests/resource_utils.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/resource_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Common test case for all resources.
+"""Common test case for all resources."""
 
-"""
 import gc
 import logging
 import re

--- a/pyvisa/testsuite/keysight_assisted_tests/test_resource_manager.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/test_resource_manager.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test the capabilities of the ResourceManager.
+"""Test the capabilities of the ResourceManager."""
 
-"""
 import gc
 import logging
 import re

--- a/pyvisa/testsuite/keysight_assisted_tests/test_rname_filter2.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/test_rname_filter2.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Common test case for all message based resources.
+"""Common test case for all message based resources."""
 
-"""
 import logging
 
 from pyvisa import ResourceManager, rname

--- a/pyvisa/testsuite/keysight_assisted_tests/test_shell.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/test_shell.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test the shell.
+"""Test the shell."""
 
-"""
 import os
 import time
 from contextlib import redirect_stdout

--- a/pyvisa/testsuite/keysight_assisted_tests/test_tcpip_resources.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/test_tcpip_resources.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test the TCPIP based resources.
+"""Test the TCPIP based resources."""
 
-"""
 import pytest
 
 from pyvisa import constants, errors

--- a/pyvisa/testsuite/keysight_assisted_tests/test_util.py
+++ b/pyvisa/testsuite/keysight_assisted_tests/test_util.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test pyvisa utility functions that requires a VISA library to be tested.
+"""Test pyvisa utility functions that requires a VISA library to be tested."""
 
-"""
 from pyvisa import util
 from pyvisa.testsuite import BaseTestCase
 

--- a/pyvisa/testsuite/test_attributes.py
+++ b/pyvisa/testsuite/test_attributes.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test attribute descriptors.
+"""Test attribute descriptors."""
 
-"""
 import enum
 
 import pytest

--- a/pyvisa/testsuite/test_cmd_line_tools.py
+++ b/pyvisa/testsuite/test_cmd_line_tools.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test the behavior of the command line tools.
+"""Test the behavior of the command line tools."""
 
-"""
 import argparse
 import sys
 from subprocess import PIPE, Popen, run

--- a/pyvisa/testsuite/test_constants.py
+++ b/pyvisa/testsuite/test_constants.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import pytest
 
 from pyvisa.constants import DataWidth

--- a/pyvisa/testsuite/test_env_var_handling.py
+++ b/pyvisa/testsuite/test_env_var_handling.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test the reading of env vars.
+"""Test the reading of env vars."""
 
-"""
 import os
 import sys
 from subprocess import PIPE, Popen

--- a/pyvisa/testsuite/test_errors.py
+++ b/pyvisa/testsuite/test_errors.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test the handling of errors.
+"""Test the handling of errors."""
 
-"""
 import pickle
 
 from pyvisa import errors
@@ -78,7 +77,7 @@ class TestLibraryError(BaseTestCase):
 
         class DummyExc(Exception):
             def __str__(self):
-                raise b"\xFF".decode("ascii")
+                raise b"\xff".decode("ascii")
 
         exc = errors.LibraryError.from_exception(
             DummyExc("visa.dll: wrong ELF class"), "visa.dll"

--- a/pyvisa/testsuite/test_event.py
+++ b/pyvisa/testsuite/test_event.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import logging
 
 import pytest

--- a/pyvisa/testsuite/test_highlevel.py
+++ b/pyvisa/testsuite/test_highlevel.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test highlevel functions not requiring an actual backend.
+"""Test highlevel functions not requiring an actual backend."""
 
-"""
 import logging
 import os
 import sys

--- a/pyvisa/testsuite/test_logging_utilities.py
+++ b/pyvisa/testsuite/test_logging_utilities.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test pyvisa utility functions that requires a VISA library to be tested.
+"""Test pyvisa utility functions that requires a VISA library to be tested."""
 
-"""
 import logging
 from io import StringIO
 

--- a/pyvisa/testsuite/test_rname.py
+++ b/pyvisa/testsuite/test_rname.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test test the resource name parsing.
+"""Test test the resource name parsing."""
 
-"""
 import logging
 from dataclasses import dataclass
 

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Test pyvisa utility functions.
+"""Test pyvisa utility functions."""
 
-"""
 import array
 import contextlib
 import logging

--- a/pyvisa/typing.py
+++ b/pyvisa/typing.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 from typing import Any, Callable, NewType
 
 from . import constants

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -7,6 +7,7 @@ This file is part of PyVISA.
 :license: MIT, see LICENSE for more details.
 
 """
+
 import functools
 import inspect
 import io


### PR DESCRIPTION
Running `ruff 0.1.6` in pre-commit but `ruff latest` in CI/dev env = bad time.

- [ ] Closes # (insert issue number if relevant)
- [x] Executed ``ruff format .`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
