### PR TITLE
add -v cmdline flag to pyvisa-shell for warn/info/debug logging output

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ PyVISA Changelog
 
 1.15.0 (unreleased)
 -------------------
+- add support for Python 3.13 PR #852
+- drop support for Python 3.8 and 3.9 PR #852
+- add a -v option to pyvisa-shell to increase log verbosity and set default to WARN PR #816
 - added support for an optional monitoring interface object to the read_binary_values() and
   query_binary_values() methods of message-based resources.
 - added the message_size() helper function to calculate the estimated size of a data

--- a/pyvisa/cmd_line_tools.py
+++ b/pyvisa/cmd_line_tools.py
@@ -40,7 +40,7 @@ def visa_main(command: Optional[str] = None) -> None:
         dest="verbosity",
         action="count",
         default=0,
-        help="verbosity; repeat up to 3 times for increased output",
+        help="verbosity; use up to 3 times for increased output",
     )
 
     if not command:
@@ -53,7 +53,7 @@ def visa_main(command: Optional[str] = None) -> None:
     args = parser.parse_args()
     logging.basicConfig(
         level={0: logging.ERROR, 1: logging.WARN, 2: logging.INFO, 3: logging.DEBUG}[
-            args.verbosity
+            min(3, args.verbosity)
         ]
     )
     if command:

--- a/pyvisa/cmd_line_tools.py
+++ b/pyvisa/cmd_line_tools.py
@@ -52,9 +52,7 @@ def visa_main(command: Optional[str] = None) -> None:
 
     args = parser.parse_args()
     logging.basicConfig(
-        level=(logging.WARN, logging.INFO, logging.DEBUG)[
-            min(2, args.verbosity)
-        ]
+        level=(logging.WARN, logging.INFO, logging.DEBUG)[min(2, args.verbosity)]
     )
     if command:
         args.command = command

--- a/pyvisa/cmd_line_tools.py
+++ b/pyvisa/cmd_line_tools.py
@@ -52,8 +52,8 @@ def visa_main(command: Optional[str] = None) -> None:
 
     args = parser.parse_args()
     logging.basicConfig(
-        level={0: logging.ERROR, 1: logging.WARN, 2: logging.INFO, 3: logging.DEBUG}[
-            min(3, args.verbosity)
+        level=(logging.WARN, logging.INFO, logging.DEBUG)[
+            min(2, args.verbosity)
         ]
     )
     if command:

--- a/pyvisa/cmd_line_tools.py
+++ b/pyvisa/cmd_line_tools.py
@@ -9,6 +9,7 @@ This file is part of PyVISA.
 """
 
 import argparse
+import logging
 from typing import Optional
 
 
@@ -34,6 +35,13 @@ def visa_main(command: Optional[str] = None) -> None:
         default=None,
         help="backend to be used (default: ivi)",
     )
+    parser.add_argument(
+        "-v",
+        dest="verbosity",
+        action="count",
+        default=0,
+        help="verbosity; repeat up to 3 times for increased output",
+    )
 
     if not command:
         subparsers = parser.add_subparsers(title="command", dest="command")
@@ -43,6 +51,11 @@ def visa_main(command: Optional[str] = None) -> None:
         subparsers.add_parser("shell", help="start the PyVISA console")
 
     args = parser.parse_args()
+    logging.basicConfig(
+        level={0: logging.ERROR, 1: logging.WARN, 2: logging.INFO, 3: logging.DEBUG}[
+            args.verbosity
+        ]
+    )
     if command:
         args.command = command
     if args.command == "info":


### PR DESCRIPTION
<!--

Thanks for wanting to contribute to PyVISA :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   ruff and mypy. You can also use pre-commit hooks (see the
   developer documentation for detailed instructions)

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->
This commit adds `-v` (or `-vv` or `-vvv` or `-v -v` or `-v -v -v`) as command line flags that can be passed to `pyvisa-shell` such that WARN (`-v`), INFO (`-vv`), or DEBUG (`-vvv`) messages will be emitted when running the shell. This can help users understand why a device is not listed that they believe should be listed when using that tool. Guidance in documentation can be added (by me, in the near future) to tell users to utilize these options if things are not working correctly. As it stands now, `pyvisa-shell` just doesn't say anything, and the only way to get increased messages is to write a Python script to do this.

This commit, along with https://github.com/pyvisa/pyvisa-py/pull/423 in the pyvisa-py, (as soon as I also update documentation appropriately) will close #758 and I expect will also close #791. 

- [ ] Partially closes #758 and partially closes #791 (see also https://github.com/pyvisa/pyvisa-py/pull/423 (TODO: update documentation)
- [x] Executed ``ruff check . && ruff format -c . --check`` with no errors
- [ ] The change is fully covered by automated unit tests (**Probably not necessary or possible for this?**)
- [ ] Documented in docs/ as appropriate (**TODO**)
- [ ] Added an entry to the CHANGES file (**TODO**)