### PR TITLE
cli: unshare pyvisa cli command implementation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ PyVISA Changelog
 
 1.15.0 (unreleased)
 -------------------
+- make `pyvisa-shell` and `pyvisa-info` handle arguments independently
 - add support for Python 3.13 PR #852
 - drop support for Python 3.8 and 3.9 PR #852
 - add a -v option to pyvisa-shell to increase log verbosity and set default to WARN PR #816

--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@ PyVISA Changelog
 
 1.15.0 (unreleased)
 -------------------
-- make `pyvisa-shell` and `pyvisa-info` handle arguments independently
+- make `pyvisa-shell` and `pyvisa-info` handle arguments independently PR #859
 - add support for Python 3.13 PR #852
 - drop support for Python 3.8 and 3.9 PR #852
 - add a -v option to pyvisa-shell to increase log verbosity and set default to WARN PR #816

--- a/pyvisa/cmd_line_tools.py
+++ b/pyvisa/cmd_line_tools.py
@@ -35,7 +35,7 @@ def get_shell_parser() -> argparse.ArgumentParser:
         dest="verbosity",
         action="count",
         default=0,
-        help="verbosity; use up to 3 times for increased output",
+        help="verbosity; use up to 2 times for increased output",
     )
 
     return parser

--- a/pyvisa/testsuite/test_cmd_line_tools.py
+++ b/pyvisa/testsuite/test_cmd_line_tools.py
@@ -2,7 +2,6 @@
 """Test the behavior of the command line tools."""
 
 import argparse
-import sys
 from subprocess import PIPE, Popen, run
 
 import pytest
@@ -14,17 +13,6 @@ from . import BaseTestCase, require_visa_lib
 
 class TestCmdLineTools(BaseTestCase):
     """Test the cmd line tools functions and scripts."""
-
-    def test_visa_main_argument_handling(self):
-        """Test we reject invalid values in visa_main."""
-        from pyvisa.cmd_line_tools import visa_main
-
-        old = sys.argv = ["python"]
-        try:
-            with pytest.raises(ValueError):
-                visa_main("unknown")
-        finally:
-            sys.argv = old
 
     def test_visa_info(self):
         """Test the visa info command line tool."""


### PR DESCRIPTION
pyvisa-shell and pyvisa-info have nothing in common besides being PyVISA CLI commands. Notice that all options are currently targeted for pyvisa-shell [1], even though argparse happily reports `--backend` and `-v` options for pyvisa-info as well. In addition to that, everything else in the shared `pyvisa_main()` is conditional on the given `command`.

Implement them separately, including the function body and argument handling. This effectively reduces the amount of code and complexity for having them available. It also enables proper handling of the commands documentation, including description line. If arguments ever needs to be shared by both commands, there can be a shared function that equally populate their parsers.

Parsers are created by standalone functions, so that other tools can easily use them, such as argparse-manpage. Even though pyvisa-info requires no extra argument, we still define a parser for it, so that users can still provide `--help` to get further instructions.

Since 2095ebae1ca9 ("remove deprecated feature planned for removal in 1.12"), there is also no `__main__` entry point for module commands, which renders subcommand parsing also not needed. Testing argument handling can therefore be also removed.

[1] 4af61c172492 ("add -v cmdline flag to pyvisa-shell for warn/info/debug logging output") intentionally attempts to add an option specifically for pyvisa-shell, but also adds it for pyvisa-info.

- [x] Executed `ruff check . && ruff format --check` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file

I haven't added tests to further exercise the code paths for options, as 4af61c172492 itself does not add it for verbose levels, and testing backends is not straightforward. Let me know if you think that is a required step to merge this.