### PR TITLE
Set 4.0.0 as the lower bound for `typing_extensions`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@ PyVISA Changelog
   transfer, including the header.
 - prevent adding duplicate paths to the DLL search path during ResourceManager
   instantiation #811
+- set 4.0.0 as the lower bound for `typing_extensions` PR #866
 
 1.14.1 (22-11-2023)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
   ]
-  dependencies = ["typing_extensions"]
+  dependencies = ["typing_extensions>=4.0.0"]
   dynamic = ["version"]
 
 


### PR DESCRIPTION
Resolves #865.
