### PR TITLE
Use fewest transfers possible in `read_binary_values`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,8 @@ PyVISA Changelog
 - add a -v option to pyvisa-shell to increase log verbosity and set default to WARN PR #816
 - added support for an optional monitoring interface object to the read_binary_values() and
   query_binary_values() methods of message-based resources.
+- automatically determine default chunk_size in read_binary_values() so only one or two
+  transfers are used for all data PR #874
 - added the message_size() helper function to calculate the estimated size of a data
   transfer, including the header.
 - prevent adding duplicate paths to the DLL search path during ResourceManager

--- a/docs/source/introduction/rvalues.rst
+++ b/docs/source/introduction/rvalues.rst
@@ -134,10 +134,12 @@ An implementation of a progress bar might look like:
 If you can read without any problem from your instrument, but cannot retrieve
 the full message when using this method (VI_ERROR_CONN_LOST,
 VI_ERROR_INV_SETUP, or Python simply crashes), try passing different values for
-``chunk_size`` (the default is 20*1024). The underlying mechanism for this issue
-is not clear but changing ``chunk_size`` has been used to work around it. Note
-that using  larger chunk sizes for large transfer may result in a speed up of
-the transfer.
+``chunk_size`` (the default is 20*1024 for the first transfer to get the header,
+then the remaining data length in a second transfer if necessary). The underlying
+mechanism for this issue is not clear but changing ``chunk_size`` has been used to
+work around it. Note that using larger chunk sizes for large transfer may result in
+a speed up of the transfer, which is why the default is to use the largest
+possible ``chunk_size`` once the data length is known.
 
 In some cases, the instrument may use a protocol that does not indicate how
 many bytes will be transferred. The Keithley 2000 for example always returns the

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -598,7 +598,9 @@ class MessageBasedResource(Resource):
              number of bytes based on the datatype. Defaults to 0.
         chunk_size : int, optional
             Size of the chunks to read from the device. Using larger chunks may
-            be faster for large amount of data.
+            be faster for large amount of data. Defaults to using one transfer
+            to read the header, and another for the remainder of the reported
+            data length.
         monitoring_interface : SupportsUpdate Protocol, optional
             Progress monitoring object with update() method that accepts the number
             of bytes read. See the tqdm documentation (a progress bar package) for
@@ -638,10 +640,11 @@ class MessageBasedResource(Resource):
 
         # Read all the data if we know what to expect.
         if data_length > 0:
+            to_read = expected_length - len(block)
             block.extend(
                 self.read_bytes(
-                    expected_length - len(block),
-                    chunk_size=chunk_size,
+                    to_read,
+                    chunk_size=chunk_size or to_read,
                     monitoring_interface=monitoring_interface,
                 )
             )


### PR DESCRIPTION
See https://github.com/pyvisa/pyvisa-py/issues/472 for more details. Essentially, I have an instrument that will lose data when too many small reads are issued. This PR makes it so `read_binary_values`, when not passed an explicit `chunk_size`, uses one transfer of default length to read the data header, then if there is more data to read, it reads it all in one more transfer. This should be more efficient and solves a problem with my instrument. Behavior for users that specify `chunk_size` is unaffected.

In order for this to work with the `pyvisa-py` backend, https://github.com/pyvisa/pyvisa-py/pull/470 needs to be merged since it currently further breaks up reads.

- [x] Executed ``ruff check . && ruff format -c . --check`` with no errors
- [x] The change is fully covered by automated unit tests
- [x] Documented in docs/as appropriate
- [x] Added an entry to the CHANGES file