### PR TITLE
Fix handling of missing secondary address for GPIB resources

### DIFF
--- a/pyvisa/resources/gpib.py
+++ b/pyvisa/resources/gpib.py
@@ -86,7 +86,7 @@ class GPIBCommand(bytes, Enum):
         For VISA SAD range from 1 to 31 and 0 is not SAD.
 
         """
-        if device_sad == 0:
+        if device_sad == 0 or device_sad == constants.VI_NO_SEC_ADDR:
             return b""
         return (95 + device_sad).to_bytes(1, "big")
 


### PR DESCRIPTION
A GPIB instrument without a secondary address will give a default value of `VI_NO_SEC_ADDR = 0xFFFF` > 160, which then throws an `OverflowError: int too big to convert`. This patch modifies `GPIBCommand.secondary_address` to check for this default value, rather than assuming the default value is 0.

Although I did not submit an issue for this, this fixes a bug in which calling `GPIBInterface.group_execute_trigger` to trigger an instrument without a secondary address results in the above error.

<!--

Thanks for wanting to contribute to PyVISA :)

Here's some guidelines to help the review process go smoothly.

1. Please write a description in this text box of the changes that are being
   made.

2. Please ensure that the code is properly formatted and typed by running
   ruff and mypy. You can also use pre-commit hooks (see the
   developer documentation for detailed instructions)

3. Please ensure that you have written units tests for the changes made/features
   added.

4. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

5. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!).

Many thanks in advance for your cooperation!

-->

- [ ] Closes # (insert issue number if relevant)
- [ ] Executed ``ruff check . && ruff format -c . --check`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
