### PR TITLE
Add support for extended block lengths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.7
+  rev: v0.11.8
   hooks:
     # Run the linter.
     - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.8
+  rev: v0.11.9
   hooks:
     # Run the linter.
     - id: ruff

--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
 PyVISA Changelog
 ================
 
-1.16.0 (unrealeased)
+1.16.0 (unreleased)
 -------------------
 - fix handling of missing secondary address for GPIB resources PR #913
+- added support for reading and writing definite-length binary blocks ≥1 GB PR #914
 
 1.15.0 (01-04-2025)
 -------------------

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -573,6 +573,8 @@ class MessageBasedResource(Resource):
         data_points: int = -1,
         chunk_size: Optional[int] = None,
         monitoring_interface: Optional[SupportsUpdate] = None,
+        length_before_block: Optional[int] = None,
+        raise_on_late_block: bool = False,
     ) -> Sequence[Union[int, float]]:
         """Read values from the device in binary format returning an iterable
         of values.
@@ -613,14 +615,14 @@ class MessageBasedResource(Resource):
         block = self._read_raw(chunk_size, monitoring_interface=monitoring_interface)
 
         if header_fmt == "ieee":
-            offset, data_length = util.parse_ieee_block_header(block)
+            offset, data_length = util.parse_ieee_block_header(block, length_before_block, raise_on_late_block)
 
         elif header_fmt == "ieee_or_rs":
-            offset, data_length = util.parse_ieee_or_rs_block_header(block, is_big_endian)
+            offset, data_length = util.parse_ieee_or_rs_block_header(block, length_before_block, raise_on_late_block)
         elif header_fmt == "rs":
-            offset, data_length = util.parse_rs_block_header(block, is_big_endian)
+            offset, data_length = util.parse_rs_block_header(block, length_before_block, raise_on_late_block)
         elif header_fmt == "hp":
-            offset, data_length = util.parse_hp_block_header(block, is_big_endian)
+            offset, data_length = util.parse_hp_block_header(block, is_big_endian, length_before_block, raise_on_late_block)
         elif header_fmt == "empty":
             offset = 0
             data_length = -1
@@ -746,6 +748,8 @@ class MessageBasedResource(Resource):
         data_points: int = 0,
         chunk_size: Optional[int] = None,
         monitoring_interface: Optional[SupportsUpdate] = None,
+        length_before_block: Optional[int] = None,
+        raise_on_late_block: bool = False,
     ) -> Sequence[Union[int, float]]:
         """Query the device for values in binary format returning an iterable
         of values.
@@ -808,6 +812,8 @@ class MessageBasedResource(Resource):
             data_points,
             chunk_size,
             monitoring_interface,
+            length_before_block,
+            raise_on_late_block,
         )
 
     def assert_trigger(self) -> None:

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -617,10 +617,8 @@ class MessageBasedResource(Resource):
         if header_fmt == "ieee":
             offset, data_length = util.parse_ieee_block_header(block, length_before_block, raise_on_late_block)
 
-        elif header_fmt == "ieee_or_rs":
-            offset, data_length = util.parse_ieee_or_rs_block_header(block, length_before_block, raise_on_late_block)
         elif header_fmt == "rs":
-            offset, data_length = util.parse_rs_block_header(block, length_before_block, raise_on_late_block)
+            offset, data_length = util.parse_ieee_or_rs_block_header(block, length_before_block, raise_on_late_block)
         elif header_fmt == "hp":
             offset, data_length = util.parse_hp_block_header(block, is_big_endian, length_before_block, raise_on_late_block)
         elif header_fmt == "empty":
@@ -792,9 +790,9 @@ class MessageBasedResource(Resource):
             Data read from the device.
 
         """
-        if header_fmt not in ("ieee", "empty", "hp", "rs", "ieee_or_rs"):
+        if header_fmt not in ("ieee", "hp", "rs", "empty"):
             raise ValueError(
-                "Invalid header format. Valid options are 'ieee', 'empty', 'hp', 'rs', and 'ieee_or_rs'"
+                "Invalid header format. Valid options are 'ieee', 'hp', 'rs', and 'empty'"
             )
 
         self.write(message)

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -615,6 +615,10 @@ class MessageBasedResource(Resource):
         if header_fmt == "ieee":
             offset, data_length = util.parse_ieee_block_header(block)
 
+        elif header_fmt == "ieee_or_rs":
+            offset, data_length = util.parse_ieee_or_rs_block_header(block, is_big_endian)
+        elif header_fmt == "rs":
+            offset, data_length = util.parse_rs_block_header(block, is_big_endian)
         elif header_fmt == "hp":
             offset, data_length = util.parse_hp_block_header(block, is_big_endian)
         elif header_fmt == "empty":
@@ -784,9 +788,9 @@ class MessageBasedResource(Resource):
             Data read from the device.
 
         """
-        if header_fmt not in ("ieee", "empty", "hp"):
+        if header_fmt not in ("ieee", "empty", "hp", "rs", "ieee_or_rs"):
             raise ValueError(
-                "Invalid header format. Valid options are 'ieee', 'empty', 'hp'"
+                "Invalid header format. Valid options are 'ieee', 'empty', 'hp', 'rs', and 'ieee_or_rs'"
             )
 
         self.write(message)

--- a/pyvisa/resources/messagebased.py
+++ b/pyvisa/resources/messagebased.py
@@ -322,6 +322,8 @@ class MessageBasedResource(Resource):
 
         if header_fmt == "ieee":
             block = util.to_ieee_block(values, datatype, is_big_endian)
+        elif header_fmt == "rs":
+            block = util.to_rs_block(values, datatype, is_big_endian)
         elif header_fmt == "hp":
             block = util.to_hp_block(values, datatype, is_big_endian)
         elif header_fmt == "empty":

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -265,7 +265,7 @@ class TestParser(BaseTestCase):
 
         # Test handling definite length block
         p = util.from_ieee_block(
-            b"#214" + s[2:],
+            b"#256" + s[2:],
             datatype="f",
             is_big_endian=False,
         )
@@ -282,7 +282,7 @@ class TestParser(BaseTestCase):
 
         # Test handling definite length block with HP header format
         p = util.from_hp_block(
-            b"#A\x0e\x00" + s[2:],
+            b"#A\x38\x00" + s[2:],
             datatype="f",
             is_big_endian=False,
             container=partial(array.array, "f"),
@@ -292,7 +292,7 @@ class TestParser(BaseTestCase):
 
         # Test handling definite length block with R&S header format
         p = util.from_rs_block(
-            b"#(14)" + s[2:],
+            b"#(56)" + s[2:],
             datatype="f",
             is_big_endian=False,
         )
@@ -302,7 +302,7 @@ class TestParser(BaseTestCase):
         # Test handling definite length block with IEEE header format with
         # the automatic format determination
         p = util.from_ieee_or_rs_block(
-            b"#214" + s[2:],
+            b"#256" + s[2:],
             datatype="f",
             is_big_endian=False,
         )
@@ -312,7 +312,7 @@ class TestParser(BaseTestCase):
         # Test handling definite length block with R&S header format with
         # the automatic format determination
         p = util.from_ieee_or_rs_block(
-            b"#(214)" + s[2:],
+            b"#(56)" + s[2:],
             datatype="f",
             is_big_endian=False,
         )
@@ -333,7 +333,7 @@ class TestParser(BaseTestCase):
         # automatic format determination
         with pytest.raises(ValueError):
             p = util.from_ieee_or_rs_block(
-                b"#A\x0e\x00" + s[2:],
+                b"#A\x38\x00" + s[2:],
                 datatype="f",
                 is_big_endian=False,
             )
@@ -471,9 +471,9 @@ class TestParser(BaseTestCase):
     def test_malformed_rs_binary_block_header_no_closing_parenthesis(self):
         values = list(range(10))
         for header, tb, fb in zip(
-            ("rs"),
-            (util.to_rs_block),
-            (util.from_ieee_or_rs_block),
+            ("rs",),
+            (util.to_rs_block,),
+            (util.from_ieee_or_rs_block,),
         ):
             block = tb(values, "h", False)
             index = block.find(b")")
@@ -484,9 +484,9 @@ class TestParser(BaseTestCase):
     def test_malformed_rs_binary_block_header_late_closing_parenthesis(self):
         values = list(range(100))
         for header, tb, fb in zip(
-            ("rs"),
-            (util.to_rs_block),
-            (util.from_ieee_or_rs_block),
+            ("rs",),
+            (util.to_rs_block,),
+            (util.from_ieee_or_rs_block,),
         ):
             block = tb(values, "h", False)
             index = block.find(b")")
@@ -536,7 +536,7 @@ class TestParser(BaseTestCase):
             if header == "ieee":
                 parse = util.parse_ieee_block_header
             elif header == "hp":
-                partial(util.parse_hp_block_header, is_big_endian=False)
+                parse = partial(util.parse_hp_block_header, is_big_endian=False)
             elif header == "rs":
                 parse = util.parse_rs_block_header
             elif header == "ieee_or_rs":

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -538,8 +538,6 @@ class TestParser(BaseTestCase):
             elif header == "hp":
                 parse = partial(util.parse_hp_block_header, is_big_endian=False)
             elif header == "rs":
-                parse = util.parse_rs_block_header
-            elif header == "ieee_or_rs":
                 parse = util.parse_ieee_or_rs_block_header
 
             with pytest.raises(RuntimeError):

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -587,6 +587,12 @@ class TestParser(BaseTestCase):
                 block = block[:2] + b"\x00\x00\x00\x00" + block[2 + 4 :]
             assert not fb(block, "h", False, list)
 
+    def test_block_length_too_large_for_header(self):
+        values = range(1_000_000_000_000_000)
+        for tb in (util.to_ieee_block, util.to_hp_block):
+            with pytest.raises(OverflowError):
+                tb(values, datatype="q")
+
     def test_handling_malformed_binary(self):
         containers = (list, tuple) + ((np.array, np.ndarray) if np else ())
 

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -444,9 +444,14 @@ class TestParser(BaseTestCase):
     def test_bytes_binary_block(self):
         values = b"dbslbw cj saj \x00\x76"
         for block, tb, fb in zip(
-            ("ieee", "hp", "rs"),
-            (util.to_ieee_block, util.to_hp_block, util.to_rs_block),
-            (util.from_ieee_block, util.from_hp_block, util.from_ieee_or_rs_block),
+            ("ieee", "hp", "rs", "rs"),
+            (util.to_ieee_block, util.to_hp_block, util.to_rs_block, util.to_rs_block),
+            (
+                util.from_ieee_block,
+                util.from_hp_block,
+                util.from_ieee_or_rs_block,
+                util.from_rs_block,
+            ),
         ):
             for fmt in "sbB":
                 block = tb(values, datatype=fmt)

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -457,16 +457,21 @@ class TestParser(BaseTestCase):
     def test_no_start_of_block_indicator_binary_block_header(self):
         values = list(range(10))
         for header, tb, fb in zip(
-            ("ieee", "hp", "rs"),
-            (util.to_ieee_block, util.to_hp_block, util.to_rs_block),
-            (util.from_ieee_block, util.from_hp_block, util.from_ieee_or_rs_block),
+            ("ieee", "hp", "rs", "rs"),
+            (util.to_ieee_block, util.to_hp_block, util.to_rs_block, util.to_rs_block),
+            (
+                util.from_ieee_block,
+                util.from_hp_block,
+                util.from_ieee_or_rs_block,
+                util.from_rs_block,
+            ),
         ):
             block = tb(values, "h", False)
             bad_block = block[1:]
             with pytest.raises(ValueError) as e:
                 fb(bad_block, "h", False, list)
 
-            assert "(#" in e.exconly()
+            assert '"#' in e.exconly()
 
     def test_malformed_rs_binary_block_header_no_closing_parenthesis(self):
         values = list(range(10))
@@ -549,8 +554,13 @@ class TestParser(BaseTestCase):
         values = list(range(99))
         for header, tb, fb in zip(
             ("ieee", "hp", "rs"),
-            (util.to_ieee_block, util.to_hp_block, util.to_rs_block),
-            (util.from_ieee_block, util.from_hp_block, util.from_ieee_or_rs_block),
+            (util.to_ieee_block, util.to_hp_block, util.to_rs_block, util.to_rs_block),
+            (
+                util.from_ieee_block,
+                util.from_hp_block,
+                util.from_ieee_or_rs_block,
+                util.from_rs_block,
+            ),
         ):
             block = tb(values, "h", False)
             if header == "ieee":

--- a/pyvisa/testsuite/test_util.py
+++ b/pyvisa/testsuite/test_util.py
@@ -558,7 +558,7 @@ class TestParser(BaseTestCase):
     def test_binary_block_shorter_than_advertized(self):
         values = list(range(99))
         for header, tb, fb in zip(
-            ("ieee", "hp", "rs"),
+            ("ieee", "hp", "rs", "rs"),
             (util.to_ieee_block, util.to_hp_block, util.to_rs_block, util.to_rs_block),
             (
                 util.from_ieee_block,

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -1094,7 +1094,7 @@ def to_rs_block(
     element_length = struct.calcsize(datatype)
     data_length = array_length * element_length
 
-    header = f'#({data_length:d})'
+    header = f"#({data_length:d})"
 
     return to_binary_block(iterable, header, datatype, is_big_endian)
 

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -476,11 +476,11 @@ def parse_ieee_block_header(
             parentheses_adjustment = 1
             if header_length < 0:
                 msg = 'Block length is indicated using parentheses syntax, but no closing parenthesis was found.'
-                raise ValueError(msg)
+                raise RuntimeError(msg)
             elif header_length > 18:
                 # ≥1 exabyte of data seems quite unlikely
                 msg = f'Unexpectedly large block length indicated using parentheses syntax. Indicated length was {header_length} decimal digits long.'
-                raise ValueError(msg)
+                raise RuntimeError(msg)
         else:
             # Tektronix and LeCroy stay with the IEEE 488 style and simply extend the length
             # digit into hexadecimal to provide up to 15 decimal digits (1 PB) instead of 9.

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -1066,7 +1066,7 @@ def to_ieee_block(
         msg = (
             "Block length in bytes cannot be greater than or equal to 1 PB "
             "(it must be representable with 15 decimal digits), but the "
-            f"block length was {data_length}, which requires "
+            f"block length was {data_length} bytes, which requires "
             f"{len(str(data_length))} digits to represent."
         )
         raise OverflowError(msg)
@@ -1137,6 +1137,14 @@ def to_hp_block(
     array_length = len(iterable)
     element_length = struct.calcsize(datatype)
     data_length = array_length * element_length
+
+    if data_length >= 2**16:
+        msg = (
+            "Block length in bytes cannot be greater than or equal to 64 KiB "
+            "(it must be representable with a 16-bit unsigned int), but the "
+            f"block length was {data_length} bytes."
+        )
+        raise OverflowError(msg)
 
     header = b"#A" + (
         int.to_bytes(data_length, 2, "big" if is_big_endian else "little")

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -392,7 +392,7 @@ def to_ascii_block(
 
 
 #: Valid binary header when reading/writing binary block of data from an instrument
-BINARY_HEADERS = Literal["ieee", "hp", "empty", "rs", "ieee_or_rs"]
+BINARY_HEADERS = Literal["ieee", "hp", "rs", "empty"]
 
 #: Valid datatype for binary block. See Python standard library struct module for more
 #: details.

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -1067,6 +1067,7 @@ def to_ieee_block(
 
     return to_binary_block(iterable, header, datatype, is_big_endian)
 
+
 def to_rs_block(
     iterable: Sequence[Union[int, float]],
     datatype: BINARY_DATATYPES = "f",
@@ -1097,6 +1098,7 @@ def to_rs_block(
     header = f"#({data_length:d})"
 
     return to_binary_block(iterable, header, datatype, is_big_endian)
+
 
 def to_hp_block(
     iterable: Sequence[Union[int, float]],

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -1078,6 +1078,7 @@ def to_ieee_block(
 
     return to_binary_block(iterable, header, datatype, is_big_endian)
 
+
 def to_rs_block(
     iterable: Sequence[Union[int, float]],
     datatype: BINARY_DATATYPES = "f",
@@ -1109,6 +1110,7 @@ def to_rs_block(
     header = f"#({data_length:d})"
 
     return to_binary_block(iterable, header, datatype, is_big_endian)
+
 
 def to_hp_block(
     iterable: Sequence[Union[int, float]],

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -473,7 +473,7 @@ def parse_ieee_block_header(
         # #3100DATA
         # 012345
 
-        if header_length == 10 and len(block[begin:]) <= (2 ** 16) + 4:
+        if header_length == 10 and len(block[begin:]) < (2 ** 16) + 4:
             # Detect an HP formatted block, which starts with "A"
             msg = (f'Block length in IEEE format was indicated as 0xA (10d) but the '
                     'block length was less than 64 KiB. It appears the block may be '
@@ -482,7 +482,7 @@ def parse_ieee_block_header(
             raise ValueError (msg)
         
         data_length = int(block[begin + 2 : offset])
-        
+
     else:
         # #0DATA
         # 012

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -455,7 +455,7 @@ def parse_ieee_block_header(
             "is an unexpectedly large value. The actual block may "
             "have been missing a beginning marker but the block "
             "contained one:\n%s"
-        ) % (begin, repr(block))
+        ) % (begin, repr(block[:begin+25]))
         if raise_on_late_block:
             raise RuntimeError(msg)
         else:
@@ -527,7 +527,7 @@ def parse_rs_block_header(
             "is an unexpectedly large value. The actual block may "
             "have been missing a beginning marker but the block "
             "contained one:\n%s"
-        ) % (begin, repr(block))
+        ) % (begin, repr(block[:begin+25]))
         if raise_on_late_block:
             raise RuntimeError(msg)
         else:

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -445,7 +445,7 @@ def parse_ieee_block_header(
     begin = block.find(b"#")
     if begin < 0:
         raise ValueError(
-            "Could not find hash sign (#) indicating the start of the block. "
+            'Could not find hash sign ("#") indicating the start of the block. '
             "The block begins with %r" % block[:25]
         )
 
@@ -631,7 +631,7 @@ def parse_ieee_or_rs_block_header(
     begin = block.find(b"#")
     if begin < 0:
         raise ValueError(
-            "Could not find hash sign (#) indicating the start of the block. "
+            'Could not find hash sign ("#") indicating the start of the block. '
             "The first 25 characters of the block: %r" % block[:25]
         )
 
@@ -679,7 +679,7 @@ def parse_hp_block_header(
     begin = block.find(b"#A")
     if begin < 0:
         raise ValueError(
-            "Could not find the standard block header (#A) indicating the start "
+            'Could not find the standard block header ("#A") indicating the start '
             "of the block. The block begins with %r" % block[:25]
         )
 
@@ -799,11 +799,6 @@ def from_rs_block(
 
     """
     offset, data_length = parse_rs_block_header(block)
-
-    # If the data length is not reported takes all the data and do not make
-    # any assumption about the termination character
-    if data_length == -1:
-        data_length = len(block) - offset
 
     if len(block) < offset + data_length:
         raise ValueError(

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -556,17 +556,23 @@ def parse_rs_block_header(
         else:
             warnings.warn(msg, UserWarning)
 
-    # Rohde & Schwarz uses the format #(length_digits)DATA when the number of bytes is
-    # larger than what can be represented with 9 decimal digits (≥1 GB). The length
-    # character is no longer used, and instead parentheses are used to delimit the
-    # length, allowing an arbitrary number of length digits.
+    # Rohde & Schwarz uses the format #(length_digits)DATA when the number of
+    # bytes exceeds what can be represented with 9 decimal digits (≥1 GB).
+    # The length character is no longer used, and instead parentheses are used
+    # to delimit the length, allowing an arbitrary number of length digits.
     header_length = (block.find(b")", begin)) - (begin + 2)
     if header_length < 0:
-        msg = "Block length is indicated using parentheses syntax, but no closing parenthesis was found."
+        msg = (
+            "Block length is indicated using parentheses syntax, but no "
+            "closing parenthesis was found."
+        )
         raise RuntimeError(msg)
     elif header_length > 18:
         # ≥1 exabyte of data seems quite unlikely
-        msg = f"Unexpectedly large block length indicated using parentheses syntax. Indicated length was {header_length} decimal digits long."
+        msg = (
+            "Unexpectedly large block length indicated using parentheses "
+            f"syntax. Indicated length was {header_length} digits long."
+        )
         raise RuntimeError(msg)
 
     """
@@ -1057,7 +1063,12 @@ def to_ieee_block(
     number_of_digits_in_data_length = f"{len(str(data_length)):X}"
 
     if len(number_of_digits_in_data_length) > 1:
-        msg = f"Block length in bytes cannot be greater than or equal to 1 PB (it must be representable with 15 decimal digits), but the block length was {data_length}, which requires {len(str(data_length))} digits to represent."
+        msg = (
+            "Block length in bytes cannot be greater than or equal to 1 PB "
+            "(it must be representable with 15 decimal digits), but the "
+            f"block length was {data_length}, which requires "
+            f"{len(str(data_length))} digits to represent."
+        )
         raise OverflowError(msg)
 
     header = f"#{number_of_digits_in_data_length}{data_length:d}"
@@ -1067,14 +1078,14 @@ def to_ieee_block(
 
     return to_binary_block(iterable, header, datatype, is_big_endian)
 
-
 def to_rs_block(
     iterable: Sequence[Union[int, float]],
     datatype: BINARY_DATATYPES = "f",
     is_big_endian: bool = False,
 ) -> bytes:
-    """Convert an iterable of numbers into a block of data in the Rohde & Schwarz format
-    for extended block lengths. This is used by R&S for blocks greater than or equal to 1 GB.
+    """Convert an iterable of numbers into a block of data in the Rohde & Schwarz
+    format for extended block lengths. This is used by R&S for blocks greater
+    than or equal to 1 GB.
 
     Parameters
     ----------
@@ -1098,7 +1109,6 @@ def to_rs_block(
     header = f"#({data_length:d})"
 
     return to_binary_block(iterable, header, datatype, is_big_endian)
-
 
 def to_hp_block(
     iterable: Sequence[Union[int, float]],

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -756,7 +756,7 @@ def from_ieee_block(
     if len(block) < offset + data_length:
         raise ValueError(
             "Binary data is incomplete. The header states %d data"
-            " bytes, but %d where received." % (data_length, len(block) - offset)
+            " bytes, but %d were received." % (data_length, len(block) - offset)
         )
 
     return from_binary_block(
@@ -808,7 +808,7 @@ def from_rs_block(
     if len(block) < offset + data_length:
         raise ValueError(
             "Binary data is incomplete. The header states %d data"
-            " bytes, but %d where received." % (data_length, len(block) - offset)
+            " bytes, but %d were received." % (data_length, len(block) - offset)
         )
 
     return from_binary_block(
@@ -863,7 +863,7 @@ def from_ieee_or_rs_block(
     if len(block) < offset + data_length:
         raise ValueError(
             "Binary data is incomplete. The header states %d data"
-            " bytes, but %d where received." % (data_length, len(block) - offset)
+            " bytes, but %d were received." % (data_length, len(block) - offset)
         )
 
     return from_binary_block(
@@ -910,7 +910,7 @@ def from_hp_block(
     if len(block) < offset + data_length:
         raise ValueError(
             "Binary data is incomplete. The header states %d data"
-            " bytes, but %d where received." % (data_length, len(block) - offset)
+            " bytes, but %d were received." % (data_length, len(block) - offset)
         )
 
     return from_binary_block(

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -392,7 +392,7 @@ def to_ascii_block(
 
 
 #: Valid binary header when reading/writing binary block of data from an instrument
-BINARY_HEADERS = Literal["ieee", "hp", "empty"]
+BINARY_HEADERS = Literal["ieee", "hp", "empty", "rs", "ieee_or_rs"]
 
 #: Valid datatype for binary block. See Python standard library struct module for more
 #: details.

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -466,12 +466,23 @@ def parse_ieee_block_header(
         header_length = int(block[begin + 1 : begin + 2], base = 16)
     except ValueError:
         header_length = 0
+
     offset = begin + 2 + header_length
 
     if header_length > 0:
         # #3100DATA
         # 012345
+
+        if header_length == 10 and len(block[begin:]) <= (2 ** 16) + 4:
+            # Detect an HP formatted block, which starts with "A"
+            msg = (f'Block length in IEEE format was indicated as 0xA (10d) but the '
+                    'block length was less than 64 KiB. It appears the block may be '
+                    'using the HP format instead of IEEE. If so, you will need to use '
+                    'the `header_fmt = "hp"` argument.')
+            raise ValueError (msg)
+        
         data_length = int(block[begin + 2 : offset])
+        
     else:
         # #0DATA
         # 012

--- a/pyvisa/util.py
+++ b/pyvisa/util.py
@@ -1036,8 +1036,16 @@ def to_ieee_block(
     element_length = struct.calcsize(datatype)
     data_length = array_length * element_length
 
-    header = f"{data_length:X}"
-    header = "#%d%s" % (len(header), header)
+    number_of_digits_in_data_length = f'{len(str(data_length)):X}'
+    
+    if len(number_of_digits_in_data_length) > 1:
+        msg = f'Block length in bytes cannot be greater than or equal to 1 PB (it must be representable with 15 decimal digits), but the block length was {data_length}, which requires {len(str(data_length))} digits to represent.'
+        raise OverflowError (msg)
+
+    header = f'#{number_of_digits_in_data_length}{data_length:d}'
+
+    # header = "%d" % data_length
+    # header = "#%d%s" % (len(header), header)
 
     return to_binary_block(iterable, header, datatype, is_big_endian)
 


### PR DESCRIPTION
This PR adds the following:

* `parse_ieee_block_header` now supports decoding blocks ≥ 1 GB using hexadecimal length digit (Tektronix/LeCroy)
* New function `parse_rs_block_header` supports decoding blocks ≥ 1 GB using parentheses-delimited length (Rohde & Schwarz)
* New `header_fmt = "rs"` option added to `read/query_binary_values()`. Internally this first calls the function `parse_ieee_or_rs_block_header`, which detects whether the block length begins with a parentheses and then calls the `ieee` or `rs` parser as appropriate. This implementation is used because R&S only uses this format when the block length exceeds 1 GB, so it's best to use automatic detection rather than need to have the user explicitly know whether it is using the parentheses format or not
* Exposes the `length_before_block` and `raise_on_late_block` options to the user interface of `read/query_binary_values()`, to allow user to set these values. Previously these were not accessible by the user, and always set to 25 and False. Some Tektronix scopes can return trace metadata in ASCII in front of the block data (before the block header) so a late block header >25 bytes can be expected, but previously it will always raise a warning :
```
UserWarning: The beginning of the block has been found at 156 which is an unexpectedly large value. The actual block may have been missing a beginning marker but the block contained one:
bytearray(b'1;8;BINARY;RI;MSB;"Ch1, DC coupling, 1.000V/div, 200.0us/div, 400000 points, Sample mode";1000;Y;"s";5.0000E-9;0.0000;124880;"V";40.0000E-3;1.0000;0.0000;1;#41000@AA?@?A?@@AB?A@C@A@')
```
In future it will be useful to add some way of retrieving this message in front of the block header (currently it is thrown away) but that is not included in this PR.

As a note, since the `header_fmt = rs` option in this implementation will interpret both IEEE (including the hex digit extension) and RS formatted blocks, it is somewhat "universal" for definite-length blocks, but doesn't detect indefinite length blocks if they happen to start with `"("`. The R&S format is only used for definite length blocks so I didn't think this would be a concern. But the user should be careful not to specify `header_fmt = rs` if an indefinite block is expected.

For the hex extension, I added a check to make sure the block length makes sense if the digit is 0xA to detect if an HP block is being decoded with the IEEE parser (the block length should be much more than 64K if there are 0xA = 10 digits, if it's not then it must have been an HP block, and an exception is raised with a descriptive message). But I don't have a way of testing this since I don't have any instruments that return blocks in HP format.

I tested that the R&S block decoding works, and the regular IEEE block decoding also still works.

- [x] Closes #911
- [ ] Executed ``ruff check . && ruff format -c . --check`` with no errors
- [x] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
 