### PR TITLE
Fix group execute trigger

### DIFF
--- a/pyvisa/resources/gpib.py
+++ b/pyvisa/resources/gpib.py
@@ -60,22 +60,22 @@ class GPIBCommand(bytes, Enum):
     configure_enable = CFE = b"\x1f"
 
     #: UNT: UNTALK
-    untalk = UNT = b"\x3f"
+    untalk = UNT = b"\x5f"
 
     #: UNL: UNLISTEN
-    unlisten = UNL = b"\x5f"
+    unlisten = UNL = b"\x3f"
 
     @staticmethod
     def talker(board_pad) -> bytes:
         """MTA: MY TALK ADDRESS."""
-        return (40 + board_pad).to_bytes(1, "big")
+        return (0x40 + board_pad).to_bytes(1, "big")
 
     MTA = talker
 
     @staticmethod
     def listener(device_pad) -> bytes:
         """MLA: MY LISTEN ADDRESS."""
-        return (20 + device_pad).to_bytes(1, "big")
+        return (0x20 + device_pad).to_bytes(1, "big")
 
     MLA = listener
 
@@ -86,7 +86,7 @@ class GPIBCommand(bytes, Enum):
         For VISA SAD range from 1 to 31 and 0 is not SAD.
 
         """
-        if device_sad == 0 or device_sad == constants.VI_NO_SEC_ADDR:
+        if device_sad == 0 or device_sad == 65535:
             return b""
         return (95 + device_sad).to_bytes(1, "big")
 
@@ -240,7 +240,6 @@ class GPIBInterface(_GPIBMixin, MessageBasedResource):
         command = GPIBCommand.talker(self.primary_address) + GPIBCommand.unlisten
 
         for resource in resources:
-            # tell device GPIB::11 to listen
             command += GPIBCommand.listener(
                 resource.primary_address
             ) + GPIBCommand.secondary_address(resource.secondary_address)


### PR DESCRIPTION
I've noticed the implementation has quite a few serious bugs. I've fixed the following:

- UNT and UNL commands were reversed. Source: [here](https://www.ni.com/docs/en-US/bundle/gpib-for-labview-nxg/page/ieee-488-command-messages.html).
- `talker` and `listener` static methods use 40 and 20 decimal as base address. It should be 40 and 20 hex.
- `secondary_address` method doesn't handle the 65535 (-1?) value set by default

- [x] Closes #929
- [ ] Executed ``ruff check . && ruff format -c . --check`` with no errors
- [ ] The change is fully covered by automated unit tests
- [ ] Documented in docs/ as appropriate
- [ ] Added an entry to the CHANGES file
