### PR TITLE
Fix warnings when resources with already closed sessions are destroyed

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 PyVISA Changelog
 ================
 
+1.16.1 (xx-xx-2026)
+-------------------
+- fix warning on closing already closed resources PR #967
+
 1.16.0 (18-12-2025)
 -------------------
 - fix handling of missing secondary address for GPIB resources PR #913

--- a/pyvisa/resources/resource.py
+++ b/pyvisa/resources/resource.py
@@ -183,7 +183,9 @@ class Resource(object):
                 # Exceptions must be suppressed during __del__, because they
                 # can't be caught by normal exception handling techniques and
                 # get printed to stderr instead
-                pass
+                logger.warning(
+                    "Exception suppressed while destroying a resource", exc_info=True
+                )
 
     def __str__(self) -> str:
         return "%s at %s" % (self.__class__.__name__, self._resource_name)
@@ -323,15 +325,12 @@ class Resource(object):
             logger.debug("%s - closing", self._resource_name, extra=self._logging_extra)
             self.before_close()
             self.visalib.close(self.session)
-            logger.debug(
-                "%s - is closed", self._resource_name, extra=self._logging_extra
-            )
             # Mypy is confused by the idea that we can set a value we cannot get
             self.session = None  # type: ignore
         except errors.InvalidSession:
-            logger.warning(
-                "Exception suppressed while closing a resource", exc_info=True
-            )
+            pass
+
+        logger.debug("%s - is closed", self._resource_name, extra=self._logging_extra)
 
     def __switch_events_off(self) -> None:
         """Switch off and discards all events."""


### PR DESCRIPTION
This is a small fix that suppresses warnings about closing already closed sessions while still complaining about other errors as described in #965. In addition it ensures that a successful closing of a session is logged in the debug stream.


- [x] Closes #965 
- [x] Executed ``ruff check . && ruff format -c . --check`` with no errors
- [x] Added an entry to the CHANGES file
- [ ] The change is fully covered by automated unit tests
- ~[ ] Documented in docs/ as appropriate~

