### PR TITLE
Add NI GPIB/ENET 100 Support.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,7 +7,10 @@ PyVISA Changelog
 1.17.0 (06-07-2026)
 -------------------
 - added support for National Instruments GPIB/ENET 100 PR #980
-
+1.17 (unreleased)
+-------------------
+- add support for context manager protocol to ResourceManager PR #985
+- added support for National Instruments GPIB/ENET 100 PR #980
 1.16.2 (29-01-2026)
 -------------------
 - fix creating a ResourceManager with visa_library string containing multiple '@' symbols PR #971

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 PyVISA Changelog
 ================
 
+1.17.0 (06-07-2026)
+-------------------
+- added support for National Instruments GPIB/ENET 100 PR #980
+
 1.16.2 (29-01-2026)
 -------------------
 - fix creating a ResourceManager with visa_library string containing multiple '@' symbols PR #971

--- a/pyvisa/constants.py
+++ b/pyvisa/constants.py
@@ -826,6 +826,9 @@ class InterfaceType(enum.IntEnum):
     #: prologix tcpip
     prlgx_tcpip = 76543  # an arbitrarily chosen value
 
+    #: NI GPIB-ENET/100
+    ni_enet100_tcpip = 76544  # similar to Prologix, hence +1
+
 
 @enum.unique
 class LineState(enum.IntEnum):

--- a/pyvisa/resources/tcpip.py
+++ b/pyvisa/resources/tcpip.py
@@ -68,3 +68,19 @@ class PrlgxTCPIPIntfc(MessageBasedResource):
     """
 
     pass
+
+
+@Resource.register(constants.InterfaceType.ni_enet100_tcpip, "INTFC")
+class NIEnet100TCPIPIntfc(Resource):
+    """Communicates with the NI GPIB-ENET/100 bridge of type
+    NI-ENET100-TCPIP::host address::INTFC
+
+    More complex resource names can be specified with the following grammar:
+        NI-ENET100-TCPIP[board]::host address::INTFC
+
+    Do not instantiate directly, use
+    :meth:`pyvisa.highlevel.ResourceManager.open_resource`.
+
+    """
+
+    pass

--- a/pyvisa/rname.py
+++ b/pyvisa/rname.py
@@ -429,6 +429,25 @@ class PrlgxTCPIPIntfc(ResourceName):
 
 @register_subclass
 @dataclass
+class NIEnet100TCPIPIntfc(ResourceName):
+    """NI-ENET100 TCPIP INTFC
+
+    The syntax is:
+    NI-ENET100-TCPIP[board]::host address::INTFC
+    """
+
+    #: GPIB "board" to use.
+    board: str = "0"
+
+    #: Host address of the device (IPv4 or host name)
+    host_address: str = ""
+
+    interface_type: ClassVar[str] = "NI-ENET100-TCPIP"
+    resource_class: ClassVar[str] = "INTFC"
+
+
+@register_subclass
+@dataclass
 class ASRLInstr(ResourceName):
     """ASRL INSTR
 

--- a/pyvisa/testsuite/test_rname.py
+++ b/pyvisa/testsuite/test_rname.py
@@ -148,8 +148,28 @@ class TestResourceName(BaseTestCase):
         """Test converting the interface to a VISA constant"""
         types = constants.InterfaceType
         for it, itc in zip(
-            ("ASRL", "USB", "GPIB", "TCPIP", "PXI", "VXI"),
-            (types.asrl, types.usb, types.gpib, types.tcpip, types.pxi, types.vxi),
+            (
+                "ASRL",
+                "USB",
+                "GPIB",
+                "TCPIP",
+                "PXI",
+                "VXI",
+                "PRLGX-TCPIP",
+                "PRLGX-ASRL",
+                "NI-ENET100-TCPIP",
+            ),
+            (
+                types.asrl,
+                types.usb,
+                types.gpib,
+                types.tcpip,
+                types.pxi,
+                types.vxi,
+                types.prlgx_tcpip,
+                types.prlgx_asrl,
+                types.ni_enet100_tcpip,
+            ),
         ):
             rn = rname.ResourceName()
             rn.interface_type = it
@@ -297,6 +317,25 @@ class TestParsers(BaseTestCase):
             serial_device="asrl1",
             board="0",
             canonical_resource_name="PRLGX-ASRL0::asrl1::INTFC",
+        )
+
+    def test_ni_enet100_intf(self):
+        self._parse_test(
+            "NI-ENET100-TCPIP::1.2.3.4::INTFC",
+            interface_type="NI-ENET100-TCPIP",
+            resource_class="INTFC",
+            host_address="1.2.3.4",
+            board="0",
+            canonical_resource_name="NI-ENET100-TCPIP0::1.2.3.4::INTFC",
+        )
+
+        self._parse_test(
+            "NI-ENET100-TCPIP3::dev.company.com::INTFC",
+            interface_type="NI-ENET100-TCPIP",
+            resource_class="INTFC",
+            host_address="dev.company.com",
+            board="3",
+            canonical_resource_name="NI-ENET100-TCPIP3::dev.company.com::INTFC",
         )
 
     def test_tcpip_intr(self):


### PR DESCRIPTION
This PR prepares pyvisa for the upcoming PR in pyvisa-py. The goal is to support new hardware: The NI GPIB-ENET 100 adapter (Ethernet/GPIB bridge).

The PR adds a new constant required by/ used by the upcoming pyvisa-py PR. Same pattern like it was done for the Prologix adapter. Test cases have been added and verified against real hardware.

- [X] Executed ``ruff check . && ruff format -c . --check`` with no errors
- [X] The change is fully covered by automated unit tests

Waiting for initial feedback, then I'll do these two:
- [ ] Documented in docs/ as appropriate
- [x] Added an entry to the CHANGES file
