### PR TITLE
Fix outdated manual install instructions in README

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ PyVISA Changelog
 1.17 (unreleased)
 -------------------
 - add support for context manager protocol to ResourceManager PR #985
+- fix outdated manual install instructions in README PR #986
 
 1.16.2 (29-01-2026)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ or download and unzip the source distribution file and, from that directory:
 
 pip can install without accessing PyPI if the build and runtime dependencies
 are already available locally, e.g. using ``--no-build-isolation`` together
-with ``--no-index --find-links=<path-to-local-wheels>``, see pip's
+with ``--no-index --find-links=<path-to-local-wheels>``. See pip's
 `local project installs
 <https://pip.pypa.io/en/stable/topics/local-project-installs/>`_
 documentation for details.

--- a/README.rst
+++ b/README.rst
@@ -89,13 +89,16 @@ Using pip:
 
     $ pip install pyvisa
 
-or easy_install:
+or download and unzip the source distribution file and, from that directory:
 
-    $ easy_install pyvisa
+    $ pip install .
 
-or download and unzip the source distribution file and:
-
-    $ python setup.py install
+pip can install without accessing PyPI if the build and runtime dependencies
+are already available locally, e.g. using ``--no-build-isolation`` together
+with ``--no-index --find-links=<path-to-local-wheels>``, see pip's
+`local project installs
+<https://pip.pypa.io/en/stable/topics/local-project-installs/>`_
+documentation for details.
 
 
 Documentation


### PR DESCRIPTION
Fixes #839.

The README told users to run `python setup.py install` after downloading the source, but the project has moved to a `pyproject.toml`-based build and no longer ships a `setup.py`, so that command fails. The `easy_install` alternative listed alongside it was also dead: `easy_install` was removed from setuptools years ago and no longer exists as a command.

This replaces both with `pip install .` run from the unzipped source directory, and adds a note on installing fully offline via `--no-build-isolation`/`--no-index --find-links` (linking pip's local-project-installs docs), which is the actual constraint the reporter has: PyPI access is blocked by their organization's policy.

This is my first contribution to pyvisa, happy to adjust wording/scope per your preference.
